### PR TITLE
Improve tag_all_repos.

### DIFF
--- a/git_tools/create_opence_release.py
+++ b/git_tools/create_opence_release.py
@@ -109,7 +109,8 @@ def _main(arg_strings=None):
                                 branch=args.branch,
                                 repo_dir=args.repo_dir,
                                 pat=args.pat,
-                                skipped_repos=args.primary_repo)
+                                skipped_repos=args.primary_repo,
+                                prev_tag=None)
 
     release = git_utils.ask_for_input("Would you like to create a github release?")
     if release.startswith("y"):

--- a/git_tools/git_utils.py
+++ b/git_tools/git_utils.py
@@ -169,12 +169,17 @@ def request_pr_review(github_org, repo, token, pull_number, reviewers=None, team
 
 def clone_repo(git_url, repo_dir, git_tag=None):
     '''Clone a repo to the given location.'''
-    if git_tag is None:
-        clone_cmd = "git clone " + git_url + " " + repo_dir
-    else:
-        clone_cmd = "git clone -b " + git_tag + " --single-branch " + git_url + " " + repo_dir
-    if utils.run_and_log(clone_cmd) != 0:
-        raise Exception("Unable to clone repository: {}".format(git_url))
+    utils.git_clone(git_url, git_tag, repo_dir)
+
+def get_tag_branch(repo_path, git_tag):
+    """
+    Find the most recent branch that contains git_tag.
+    """
+    saved_working_directory = os.getcwd()
+    os.chdir(repo_path)
+    retval = utils.get_branch_of_tag(git_tag)
+    os.chdir(saved_working_directory)
+    return retval
 
 def _execute_git_command(repo_path, git_cmd):
     saved_working_directory = os.getcwd()

--- a/git_tools/tag_all_repos.py
+++ b/git_tools/tag_all_repos.py
@@ -45,10 +45,12 @@ def _make_parser():
     ''' Parser input arguments '''
     parser = inputs.make_parser([git_utils.Argument.PUBLIC_ACCESS_TOKEN, git_utils.Argument.REPO_DIR,
                                     git_utils.Argument.BRANCH, git_utils.Argument.ORG, git_utils.Argument.SKIPPED_REPOS],
-                                    description = """Tag all repos in an organization using the following logic:
+                                    description = """
+                                    Tag all repos in an organization using the following logic:
                                     1- If the branch argument is passed in and that branch exists in the repo, the tag will be made at the tip of that branch.
                                     2- Otherwise, if a previous-tag is passed, the tag will be made at the tip of the latest branch which contains that tag.
-                                    3- Finally, if none of these cases hold, the tag is made at the tip of the default branch.""")
+                                    3- Finally, if none of these cases hold, the tag is made at the tip of the default branch.
+                                    """)
 
     parser.add_argument(
         '--tag',

--- a/git_tools/tag_all_repos.py
+++ b/git_tools/tag_all_repos.py
@@ -48,7 +48,7 @@ def _make_parser():
                                     description = """Tag all repos in an organization using the following logic:
                                     1- If the branch argument is passed in and that branch exists in the repo, the tag will be made at the tip of that branch.
                                     2- Otherwise, if a previous-tag is passed, the tag will be made at the tip of the latest branch which contains that tag.
-                                    3- Finally, if none of these cases hold, the tag is made in the default branch.""")
+                                    3- Finally, if none of these cases hold, the tag is made at the tip of the default branch.""")
 
     parser.add_argument(
         '--tag',

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -274,7 +274,7 @@ def replace_conda_env_channels(conda_env_file, original_channel, new_channel):
     with open(conda_env_file, 'w') as file_handle:
         yaml.safe_dump(env_info, file_handle)
 
-def _get_branch_of_tag(git_tag):
+def get_branch_of_tag(git_tag):
     """
     Find the most recent branch that contains git_tag.
     """
@@ -305,7 +305,7 @@ def git_clone(git_url, git_tag, location, up_to_date=False):
         if git_tag:
             os.chdir(location)
             if up_to_date:
-                git_tag = _get_branch_of_tag(git_tag)
+                git_tag = get_branch_of_tag(git_tag)
             checkout_cmd = "git checkout " + git_tag
             print("Checkout branch/tag command: ", checkout_cmd)
             checkout_res = os.system(checkout_cmd)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -131,7 +131,7 @@ def test_get_branch_of_tag(mocker):
     sample_output = "main\n  remotes/origin/main\n* remotes/origin/r2.4.1   \n"
     mocker.patch('open_ce.utils.run_command_capture', side_effect=[(True, sample_output, ""), (False, sample_output, "")])
 
-    assert utils._get_branch_of_tag("mytag") == "remotes/origin/r2.4.1"
+    assert utils.get_branch_of_tag("mytag") == "remotes/origin/r2.4.1"
 
-    assert utils._get_branch_of_tag("mytag") == "mytag"
+    assert utils.get_branch_of_tag("mytag") == "mytag"
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?

## Description

Fixes #6 

This change should allow us to tag a bug fix for a previous release, and feedstock tagging will follow the following logic:

1. If the branch argument is passed in and that branch exists in the repo, the tag will be made at the tip of that branch.
2. Otherwise, if a previous-tag is passed, the tag will be made at the tip of the latest branch which contains that tag.
3. Finally, if none of these cases hold, the tag is made at the tip of the default branch
