### PR TITLE
Enable podman builds as root

### DIFF
--- a/open_ce/build_env.py
+++ b/open_ce/build_env.py
@@ -19,7 +19,6 @@
 
 import os
 import sys
-import glob
 
 from open_ce import build_feedstock
 from open_ce import container_build
@@ -89,14 +88,7 @@ def build_env(args):
     if args.container_build:
         if len(args.cuda_versions.split(',')) > 1:
             raise OpenCEError(Error.TOO_MANY_CUDA)
-        try:
-            container_build.build_with_container_tool(args, sys.argv)
-        finally:
-            for conda_env_file in glob.glob(os.path.join(args.output_folder, "*.yaml")):
-                utils.replace_conda_env_channels(conda_env_file,
-                                                 os.path.abspath(os.path.join(container_build.HOME_PATH,
-                                                                              utils.DEFAULT_OUTPUT_FOLDER)),
-                                                 os.path.abspath(args.output_folder))
+        container_build.build_with_container_tool(args, sys.argv)
         return
 
     # Checking conda-build existence if --container_build is not specified

--- a/open_ce/container_build.py
+++ b/open_ce/container_build.py
@@ -31,7 +31,7 @@ BUILD_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images", BUILD_IMAGE_NAME)
 BUILD_CUDA_IMAGE_NAME = "builder-cuda-" + platform.machine()
 BUILD_CUDA_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images", BUILD_CUDA_IMAGE_NAME)
 LOCAL_FILES_PATH = os.path.join(os.path.join(os.getcwd(), "local_files"))
-HOME_PATH = "/home/builder"
+HOME_PATH = "/root"
 
 REPO_NAME = "open-ce"
 IMAGE_NAME = "open-ce-builder"
@@ -64,8 +64,6 @@ def build_image(build_image_path, dockerfile, container_tool, cuda_version=None,
     build_cmd = container_tool + " build "
     build_cmd += "-f " + dockerfile + " "
     build_cmd += "-t " + image_name + " "
-    build_cmd += "--build-arg BUILD_ID=" + str(os.getuid()) + " "
-    build_cmd += "--build-arg GROUP_ID=" + str(os.getgid()) + " "
 
     build_cmd += container_build_args + " "
     build_cmd += build_image_path
@@ -100,7 +98,7 @@ def _create_container(container_name, image_name, output_folder, env_folders, co
     Create a container
     """
     # Create the container
-    container_cmd = container_tool + " create" + (" --userns=keep-id" if container_tool=="podman" else "" )\
+    container_cmd = container_tool + " create"\
                  + " -i --rm --name " + container_name + " "
 
     # Add output folder
@@ -131,6 +129,8 @@ def _start_container(container_name, container_tool):
 
 def _execute_in_container(container_name, command, container_tool):
     container_cmd = container_tool + " exec " + container_name + " "
+    if container_tool == "docker":
+        container_cmd += "--user " + str(os.getuid()) + ":" + str(os.getgid()) + " "
     # Change to home directory
     container_cmd += "bash -c 'cd " + HOME_PATH + "; " + command + "'"
 

--- a/open_ce/container_build.py
+++ b/open_ce/container_build.py
@@ -64,6 +64,8 @@ def build_image(build_image_path, dockerfile, container_tool, cuda_version=None,
     build_cmd = container_tool + " build "
     build_cmd += "-f " + dockerfile + " "
     build_cmd += "-t " + image_name + " "
+    build_cmd += "--build-arg BUILD_ID=" + str(os.getuid()) + " "
+    build_cmd += "--build-arg GROUP_ID=" + str(os.getgid()) + " "
 
     build_cmd += container_build_args + " "
     build_cmd += build_image_path
@@ -128,9 +130,10 @@ def _start_container(container_name, container_tool):
         raise OpenCEError(Error.START_CONTAINER, container_name)
 
 def _execute_in_container(container_name, command, container_tool):
-    container_cmd = container_tool + " exec " + container_name + " "
-    if container_tool == "docker":
-        container_cmd += "--user " + str(os.getuid()) + ":" + str(os.getgid()) + " "
+    container_cmd = container_tool + " exec "
+    if container_tool == "podman" or os.getuid() == 0:
+        container_cmd += "--user root "
+    container_cmd += container_name + " "
     # Change to home directory
     container_cmd += "bash -c 'cd " + HOME_PATH + "; " + command + "'"
 

--- a/open_ce/images/builder-cuda-ppc64le/Dockerfile.cuda-10.2
+++ b/open_ce/images/builder-cuda-ppc64le/Dockerfile.cuda-10.2
@@ -14,39 +14,32 @@ ARG BUILD_ID=1084
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
-# Install basic requirements.
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y \
-    sudo \
-    bzip2 \
-    git \
-    patch && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder
     useradd -b /home --non-unique --create-home --gid ${GROUP_ID} --groups wheel \
     --uid ${BUILD_ID} --comment "User for Building" ${BUILD_USER} && \
-    echo "${BUILD_USER}    ALL=NOPASSWD: ALL" > /etc/sudoers.d/user-${BUILD_USER} && \
     curl -o /tmp/anaconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh && \
     chmod +x /tmp/anaconda.sh && \
     /bin/bash /tmp/anaconda.sh -f -b -p /opt/conda && \
     rm -f /tmp/anaconda.sh && \
-    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx && \
-    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
-
-USER ${BUILD_USER}
-RUN export PATH="${PATH}" && \
-    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx git patch && \
     $CONDA_HOME/bin/conda config --system --add envs_dirs $CONDA_HOME/envs && \
     $CONDA_HOME/bin/conda config --system --add pkgs_dirs $CONDA_HOME/pkgs && \
     $CONDA_HOME/bin/conda config --system --set always_yes true && \
     $CONDA_HOME/bin/conda config --system --set auto_update_conda false && \
     $CONDA_HOME/bin/conda config --system --set notify_outdated_conda false && \
+    $CONDA_HOME/bin/conda --version && \
     mkdir -p $CONDA_HOME/conda-bld && \
     mkdir -p $HOME/.cache && \
-    $CONDA_HOME/bin/conda --version && \
-    sudo rm -f /run/nologin && \
-    yes | ssh-keygen -f $HOME/.ssh/id_rsa -q -t rsa -N '' && cp $HOME/.ssh/id_rsa.pub $HOME/.ssh/authorized_keys && \
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
+    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
+
+USER ${BUILD_USER}
+RUN export PATH="${PATH}" && \
+    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    mkdir -p $HOME/.cache && \
     echo ". $CONDA_HOME/etc/profile.d/conda.sh" >> ${HOME}/.bashrc && \
     echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
     echo "conda activate base" >> ${HOME}/.bashrc

--- a/open_ce/images/builder-cuda-ppc64le/Dockerfile.cuda-11.0
+++ b/open_ce/images/builder-cuda-ppc64le/Dockerfile.cuda-11.0
@@ -14,40 +14,33 @@ ARG BUILD_ID=1084
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
-# Install basic requirements.
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y \
-    sudo \
-    bzip2 \
-    rsync \
-    git \
-    patch && \
+    yum repolist && yum install -y rsync && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder
     useradd -b /home --non-unique --create-home --gid ${GROUP_ID} --groups wheel \
     --uid ${BUILD_ID} --comment "User for Building" ${BUILD_USER} && \
-    echo "${BUILD_USER}    ALL=NOPASSWD: ALL" > /etc/sudoers.d/user-${BUILD_USER} && \
     curl -o /tmp/anaconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh && \
     chmod +x /tmp/anaconda.sh && \
     /bin/bash /tmp/anaconda.sh -f -b -p /opt/conda && \
     rm -f /tmp/anaconda.sh && \
-    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx && \
-    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
-
-USER ${BUILD_USER}
-RUN export PATH="${PATH}" && \
-    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx git patch && \
     $CONDA_HOME/bin/conda config --system --add envs_dirs $CONDA_HOME/envs && \
     $CONDA_HOME/bin/conda config --system --add pkgs_dirs $CONDA_HOME/pkgs && \
     $CONDA_HOME/bin/conda config --system --set always_yes true && \
     $CONDA_HOME/bin/conda config --system --set auto_update_conda false && \
     $CONDA_HOME/bin/conda config --system --set notify_outdated_conda false && \
+    $CONDA_HOME/bin/conda --version && \
     mkdir -p $CONDA_HOME/conda-bld && \
     mkdir -p $HOME/.cache && \
-    $CONDA_HOME/bin/conda --version && \
-    sudo rm -f /run/nologin && \
-    yes | ssh-keygen -f $HOME/.ssh/id_rsa -q -t rsa -N '' && cp $HOME/.ssh/id_rsa.pub $HOME/.ssh/authorized_keys && \
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
+    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
+
+USER ${BUILD_USER}
+RUN export PATH="${PATH}" && \
+    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    mkdir -p $HOME/.cache && \
     echo ". $CONDA_HOME/etc/profile.d/conda.sh" >> ${HOME}/.bashrc && \
     echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
     echo "conda activate base" >> ${HOME}/.bashrc

--- a/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-10.2
+++ b/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-10.2
@@ -14,18 +14,6 @@ ARG BUILD_ID=1084
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
-FROM registry.access.redhat.com/ubi7/ubi
-
-ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
-ENV PATH=$CONDA_HOME/bin:$PATH
-
-ENV OPEN_CE_CONDA_BUILD=3.20.5
-
-ENV CICD_GROUP=cicd
-ARG GROUP_ID=1500
-ENV BUILD_USER=builder
-ARG BUILD_ID=1084
-
 RUN export ARCH="$(uname -m)" && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \

--- a/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-10.2
+++ b/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-10.2
@@ -14,29 +14,29 @@ ARG BUILD_ID=1084
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
-# Install basic requirements.
+FROM registry.access.redhat.com/ubi7/ubi
+
+ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
+ENV PATH=$CONDA_HOME/bin:$PATH
+
+ENV OPEN_CE_CONDA_BUILD=3.20.5
+
+ENV CICD_GROUP=cicd
+ARG GROUP_ID=1500
+ENV BUILD_USER=builder
+ARG BUILD_ID=1084
+
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y \
-    sudo \
-    bzip2 \
-    git \
-    patch && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder
     useradd -b /home --non-unique --create-home --gid ${GROUP_ID} --groups wheel \
     --uid ${BUILD_ID} --comment "User for Building" ${BUILD_USER} && \
-    echo "${BUILD_USER}    ALL=NOPASSWD: ALL" > /etc/sudoers.d/user-${BUILD_USER} && \
     curl -o /tmp/anaconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh && \
     chmod +x /tmp/anaconda.sh && \
     /bin/bash /tmp/anaconda.sh -f -b -p /opt/conda && \
     rm -f /tmp/anaconda.sh && \
-    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx && \
-    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
-
-USER ${BUILD_USER}
-RUN export PATH="${PATH}" && \
-    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx git patch && \
     $CONDA_HOME/bin/conda config --system --add envs_dirs $CONDA_HOME/envs && \
     $CONDA_HOME/bin/conda config --system --add pkgs_dirs $CONDA_HOME/pkgs && \
     $CONDA_HOME/bin/conda config --system --set always_yes true && \
@@ -45,8 +45,14 @@ RUN export PATH="${PATH}" && \
     $CONDA_HOME/bin/conda --version && \
     mkdir -p $CONDA_HOME/conda-bld && \
     mkdir -p $HOME/.cache && \
-    sudo rm -f /run/nologin && \
-    yes | ssh-keygen -f $HOME/.ssh/id_rsa -q -t rsa -N '' && cp $HOME/.ssh/id_rsa.pub $HOME/.ssh/authorized_keys && \
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
+    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
+
+USER ${BUILD_USER}
+RUN export PATH="${PATH}" && \
+    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    mkdir -p $HOME/.cache && \
     echo ". $CONDA_HOME/etc/profile.d/conda.sh" >> ${HOME}/.bashrc && \
     echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
     echo "conda activate base" >> ${HOME}/.bashrc
+

--- a/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-11.0
+++ b/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-11.0
@@ -14,18 +14,6 @@ ARG BUILD_ID=1084
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
-FROM registry.access.redhat.com/ubi7/ubi
-
-ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
-ENV PATH=$CONDA_HOME/bin:$PATH
-
-ENV OPEN_CE_CONDA_BUILD=3.20.5
-
-ENV CICD_GROUP=cicd
-ARG GROUP_ID=1500
-ENV BUILD_USER=builder
-ARG BUILD_ID=1084
-
 RUN export ARCH="$(uname -m)" && \
     yum repolist && yum install -y rsync && \
     # Create CICD Group

--- a/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-11.0
+++ b/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-11.0
@@ -14,30 +14,30 @@ ARG BUILD_ID=1084
 # Remove preinclude system compilers
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
-# Install basic requirements.
+FROM registry.access.redhat.com/ubi7/ubi
+
+ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
+ENV PATH=$CONDA_HOME/bin:$PATH
+
+ENV OPEN_CE_CONDA_BUILD=3.20.5
+
+ENV CICD_GROUP=cicd
+ARG GROUP_ID=1500
+ENV BUILD_USER=builder
+ARG BUILD_ID=1084
+
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y \
-    sudo \
-    bzip2 \
-    rsync \
-    git \
-    patch && \
+    yum repolist && yum install -y rsync && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder
     useradd -b /home --non-unique --create-home --gid ${GROUP_ID} --groups wheel \
     --uid ${BUILD_ID} --comment "User for Building" ${BUILD_USER} && \
-    echo "${BUILD_USER}    ALL=NOPASSWD: ALL" > /etc/sudoers.d/user-${BUILD_USER} && \
     curl -o /tmp/anaconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh && \
     chmod +x /tmp/anaconda.sh && \
     /bin/bash /tmp/anaconda.sh -f -b -p /opt/conda && \
     rm -f /tmp/anaconda.sh && \
-    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx && \
-    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
-
-USER ${BUILD_USER}
-RUN export PATH="${PATH}" && \
-    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx git patch && \
     $CONDA_HOME/bin/conda config --system --add envs_dirs $CONDA_HOME/envs && \
     $CONDA_HOME/bin/conda config --system --add pkgs_dirs $CONDA_HOME/pkgs && \
     $CONDA_HOME/bin/conda config --system --set always_yes true && \
@@ -46,8 +46,13 @@ RUN export PATH="${PATH}" && \
     $CONDA_HOME/bin/conda --version && \
     mkdir -p $CONDA_HOME/conda-bld && \
     mkdir -p $HOME/.cache && \
-    sudo rm -f /run/nologin && \
-    yes | ssh-keygen -f $HOME/.ssh/id_rsa -q -t rsa -N '' && cp $HOME/.ssh/id_rsa.pub $HOME/.ssh/authorized_keys && \
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
+    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
+
+USER ${BUILD_USER}
+RUN export PATH="${PATH}" && \
+    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    mkdir -p $HOME/.cache && \
     echo ". $CONDA_HOME/etc/profile.d/conda.sh" >> ${HOME}/.bashrc && \
     echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
     echo "conda activate base" >> ${HOME}/.bashrc

--- a/open_ce/images/builder/Dockerfile
+++ b/open_ce/images/builder/Dockerfile
@@ -5,15 +5,22 @@ ENV PATH=$CONDA_HOME/bin:$PATH
 
 ENV OPEN_CE_CONDA_BUILD=3.20.5
 
+ENV CICD_GROUP=cicd
+ARG GROUP_ID=1500
+ENV BUILD_USER=builder
+ARG BUILD_ID=1084
+
 RUN export ARCH="$(uname -m)" && \
+    # Create CICD Group
+    groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
+    # Adduser Builder
+    useradd -b /home --non-unique --create-home --gid ${GROUP_ID} --groups wheel \
+    --uid ${BUILD_ID} --comment "User for Building" ${BUILD_USER} && \
     curl -o /tmp/anaconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh && \
     chmod +x /tmp/anaconda.sh && \
     /bin/bash /tmp/anaconda.sh -f -b -p /opt/conda && \
     rm -f /tmp/anaconda.sh && \
-    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx git patch
-
-RUN export PATH="${PATH}" && \
-    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx git patch && \
     $CONDA_HOME/bin/conda config --system --add envs_dirs $CONDA_HOME/envs && \
     $CONDA_HOME/bin/conda config --system --add pkgs_dirs $CONDA_HOME/pkgs && \
     $CONDA_HOME/bin/conda config --system --set always_yes true && \
@@ -22,4 +29,13 @@ RUN export PATH="${PATH}" && \
     $CONDA_HOME/bin/conda --version && \
     mkdir -p $CONDA_HOME/conda-bld && \
     mkdir -p $HOME/.cache && \
-    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
+    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
+
+USER ${BUILD_USER}
+RUN export PATH="${PATH}" && \
+    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    mkdir -p $HOME/.cache && \
+    echo ". $CONDA_HOME/etc/profile.d/conda.sh" >> ${HOME}/.bashrc && \
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
+    echo "conda activate base" >> ${HOME}/.bashrc

--- a/open_ce/images/builder/Dockerfile
+++ b/open_ce/images/builder/Dockerfile
@@ -5,31 +5,13 @@ ENV PATH=$CONDA_HOME/bin:$PATH
 
 ENV OPEN_CE_CONDA_BUILD=3.20.5
 
-ENV CICD_GROUP=cicd
-ARG GROUP_ID=1500
-ENV BUILD_USER=builder
-ARG BUILD_ID=1084
-
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y \
-    sudo \
-    bzip2 \
-    git \
-    patch && \
-    # Create CICD Group
-    groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
-    # Adduser Builder
-    useradd -b /home --non-unique --create-home --gid ${GROUP_ID} --groups wheel \
-    --uid ${BUILD_ID} --comment "User for Building" ${BUILD_USER} && \
-    echo "${BUILD_USER}    ALL=NOPASSWD: ALL" > /etc/sudoers.d/user-${BUILD_USER} && \
     curl -o /tmp/anaconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh && \
     chmod +x /tmp/anaconda.sh && \
     /bin/bash /tmp/anaconda.sh -f -b -p /opt/conda && \
     rm -f /tmp/anaconda.sh && \
-    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx && \
-    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
+    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} networkx git patch
 
-USER ${BUILD_USER}
 RUN export PATH="${PATH}" && \
     echo "PATH="${PATH}"" >> ${HOME}/.profile && \
     $CONDA_HOME/bin/conda config --system --add envs_dirs $CONDA_HOME/envs && \
@@ -40,8 +22,4 @@ RUN export PATH="${PATH}" && \
     $CONDA_HOME/bin/conda --version && \
     mkdir -p $CONDA_HOME/conda-bld && \
     mkdir -p $HOME/.cache && \
-    sudo rm -f /run/nologin && \
-    yes | ssh-keygen -f $HOME/.ssh/id_rsa -q -t rsa -N '' && cp $HOME/.ssh/id_rsa.pub $HOME/.ssh/authorized_keys && \
-    echo ". $CONDA_HOME/etc/profile.d/conda.sh" >> ${HOME}/.bashrc && \
-    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
-    echo "conda activate base" >> ${HOME}/.bashrc
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes #21 

This PR will:
* Make sure environment variables are setup correctly for both the root user and builder user within the image.
* Run as the builder user within the container when launching `--container_build` with `--docker_tool docker` as a non-root user.
* Run as the root user within the container when launching `--container_build` with `--docker_tool docker` as the root user.
* Run as the root user within the container when launching `--container_build` with `--docker_tool podman`.
* Cleans up the Dockerfiles some as well. Removing some unnecessary commands.
* Moves the code for fixing conda environment files channels to `container_build.py`.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
