### PR TITLE
Add parallel loops to BuildTree

### DIFF
--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -276,6 +276,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         create_commands_args = []
         # Create recipe dictionaries for each repository in the environment file
         for env_config_data in env_config_data_list:
+            channels = self._channels + env_config_data.get(env_config.Key.channels.name, [])
             feedstocks = env_config_data.get(env_config.Key.packages.name, [])
             if not feedstocks:
                 feedstocks = []

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -220,7 +220,6 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             self._initial_nodes += variant_start_nodes
 
             validate_args.append((self._tree, external_deps, variant_start_nodes))
-            #validate_config.validate_build_tree(self._tree, external_deps, variant_start_nodes)
             installable_packages = get_installable_packages(self._tree, external_deps, variant_start_nodes)
 
             filtered_packages = [package for package in installable_packages

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -17,6 +17,8 @@
 """
 
 import os
+import multiprocessing as mp
+
 import networkx
 from open_ce import utils
 from open_ce import env_config
@@ -39,6 +41,7 @@ class DependencyNode():
         self.channels = channels
         if not self.channels:
             self.channels = []
+        self._hash_val = hash(str(self.packages) + str(self.build_command))
 
     def __repr__(self):
         return str(self)
@@ -47,7 +50,7 @@ class DependencyNode():
         return "({} : {})".format(self.packages, self.build_command)
 
     def __hash__(self):
-        return hash(self.__repr__())
+        return self._hash_val
 
     def __eq__(self, other):
         if not isinstance(other, DependencyNode):
@@ -188,6 +191,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         # of variants.
         self._possible_variants = utils.make_variants(python_versions, build_types, mpi_types, cuda_versions)
         self._tree = networkx.DiGraph()
+        validate_args = []
         for variant in self._possible_variants:
             try:
                 variant_tree, external_deps = self._create_nodes(variant)
@@ -215,7 +219,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
             self._initial_nodes += variant_start_nodes
 
-            validate_config.validate_build_tree(self._tree, external_deps, variant_start_nodes)
+            validate_args.append((self._tree, external_deps, variant_start_nodes))
+            #validate_config.validate_build_tree(self._tree, external_deps, variant_start_nodes)
             installable_packages = get_installable_packages(self._tree, external_deps, variant_start_nodes)
 
             filtered_packages = [package for package in installable_packages
@@ -228,6 +233,11 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             self._test_feedstocks[variant_string] = []
             for build_command in traverse_build_commands(self._tree, variant_start_nodes):
                 self._test_feedstocks[variant_string].append(build_command.repository)
+
+        # Execute _create_commands_helper in parallel
+        pool = mp.Pool(utils.NUM_THREAD_POOL)
+        pool.starmap(validate_config.validate_build_tree, validate_args)
+        pool.close()
 
     def _get_repo(self, env_config_data, package):
         # If the feedstock value starts with any of the SUPPORTED_GIT_PROTOCOLS, treat it as a url. Otherwise
@@ -263,9 +273,9 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         feedstocks_seen = set()
         external_deps = []
         retval = networkx.DiGraph()
+        create_commands_args = []
         # Create recipe dictionaries for each repository in the environment file
         for env_config_data in env_config_data_list:
-            channels = self._channels + env_config_data.get(env_config.Key.channels.name, [])
             feedstocks = env_config_data.get(env_config.Key.packages.name, [])
             if not feedstocks:
                 feedstocks = []
@@ -273,17 +283,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                 if _make_hash(feedstock) in feedstocks_seen:
                     continue
 
-                repo_dir = self._get_repo(env_config_data, feedstock)
-                runtime_package = feedstock.get(env_config.Key.runtime_package.name, True)
-                retval = networkx.compose(retval,
-                                          _create_commands(repo_dir,
-                                                            runtime_package,
-                                                            feedstock.get(env_config.Key.recipe_path.name),
-                                                            feedstock.get(env_config.Key.recipes.name),
-                                                            [os.path.abspath(self._conda_build_config)],
-                                                            variants,
-                                                            channels))
-
+                # Create arguments for call to _create_commands_helper
+                create_commands_args.append((variants, env_config_data, feedstock))
                 feedstocks_seen.add(_make_hash(feedstock))
 
             current_deps = env_config_data.get(env_config.Key.external_dependencies.name, [])
@@ -294,7 +295,30 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
             if current_deps:
                 external_deps += current_deps
+
+        # Execute _create_commands_helper in parallel
+        pool = mp.Pool(utils.NUM_THREAD_POOL)
+        commands = pool.starmap(self._create_commands_helper, create_commands_args)
+        pool.close()
+
+        # Add the results of _create_commands_helper to the graph
+        for command in commands:
+            retval = networkx.compose(retval, command)
+
         return retval, external_deps
+
+    def _create_commands_helper(self, variants, env_config_data, feedstock):
+        channels = self._channels + env_config_data.get(env_config.Key.channels.name, [])
+        repo_dir = self._get_repo(env_config_data, feedstock)
+        runtime_package = feedstock.get(env_config.Key.runtime_package.name, True)
+        retval = _create_commands(repo_dir,
+                                  runtime_package,
+                                  feedstock.get(env_config.Key.recipe_path.name),
+                                  feedstock.get(env_config.Key.recipes.name),
+                                  [os.path.abspath(self._conda_build_config)],
+                                  variants,
+                                  channels)
+        return retval
 
     def _create_remote_deps(self, dep_graph):
         #pylint: disable=import-outside-toplevel

--- a/open_ce/errors.py
+++ b/open_ce/errors.py
@@ -63,6 +63,10 @@ class OpenCEError(Exception):
     Exception class for errors that occur in an Open-CE tool.
     """
     def __init__(self, error, *additional_args, **kwargs):
-        msg = "[OPEN-CE-ERROR-{}] {}".format(error.value[0], error.value[1].format(*additional_args))
+        # When pickling, error can already be a string.
+        if isinstance(error, str):
+            msg = error
+        else:
+            msg = "[OPEN-CE-ERROR-{}] {}".format(error.value[0], error.value[1].format(*additional_args))
         super().__init__(msg, **kwargs)
         self.msg = msg

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -52,6 +52,7 @@ OPEN_CE_INFO_FILE = "open-ce-info.yaml"
 CONTAINER_TOOLS = ["podman", "docker"]
 DEFAULT_CONTAINER_TOOL = next(filter(lambda tool: os.system("which {} &> /dev/null".format(tool))
                                       == 0, CONTAINER_TOOLS), None)
+NUM_THREAD_POOL = 16
 
 def make_variants(python_versions=DEFAULT_PYTHON_VERS, build_types=DEFAULT_BUILD_TYPES, mpi_types=DEFAULT_MPI_TYPES,
 cuda_versions=DEFAULT_CUDA_VERS):

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -70,7 +70,8 @@ def test_build_env(mocker, capsys):
         side_effect=dirTracker.validate_chdir
     )
     mocker.patch(
-        'open_ce.validate_config.validate_build_tree'
+        'open_ce.utils.run_command_capture',
+        return_val=(True, "", "")
     )
     #            +-------+
     #     +------+   15  +-----+

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -71,7 +71,7 @@ def test_build_env(mocker, capsys):
     )
     mocker.patch(
         'open_ce.utils.run_command_capture',
-        return_val=(True, "", "")
+        return_value=(True, "", "")
     )
     #            +-------+
     #     +------+   15  +-----+


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Move 2 functions during creating a BuildTree into parallel loops.
* Creating the build commands for each feedstock will be done in parallel.
* Validating each variant environment will be done in paralle.

Also modified the hash function for a DependencyNode a little bit to improve performance.

The OpenCEError exception had to be modified a little bit to handle how python pickles exceptions, which happens when they occur in a parallel loop.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
