### PR TITLE
Remove package filter.

### DIFF
--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -218,13 +218,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             validate_config.validate_build_tree(self._tree, external_deps, variant_start_nodes)
             installable_packages = get_installable_packages(self._tree, external_deps, variant_start_nodes)
 
-            filtered_packages = [package for package in installable_packages
-                                     if utils.remove_version(package) in {x for node in variant_start_nodes
-                                                                                     if node.build_command
-                                                                            for x in node.build_command.packages} or
-                                        utils.remove_version(package) in utils.KNOWN_VARIANT_PACKAGES]
-
-            self._conda_env_files[variant_string] = CondaEnvFileGenerator(filtered_packages)
+            self._conda_env_files[variant_string] = CondaEnvFileGenerator(installable_packages)
             self._test_feedstocks[variant_string] = []
             for build_command in traverse_build_commands(self._tree, variant_start_nodes):
                 self._test_feedstocks[variant_string].append(build_command.repository)
@@ -561,6 +555,6 @@ def get_installable_packages(build_commands, external_deps, starting_nodes=None,
                                                     retval)
 
     for dep in external_deps:
-        if is_independent(DependencyNode({dep}), build_commands):
+        if not independent or is_independent(DependencyNode({dep}), build_commands):
             retval = check_and_add({dep}, retval)
     return sorted(retval, key=len)

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -216,9 +216,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             self._initial_nodes += variant_start_nodes
 
             validate_config.validate_build_tree(self._tree, external_deps, variant_start_nodes)
-            installable_packages = get_installable_packages(self._tree, external_deps, variant_start_nodes)
 
-            self._conda_env_files[variant_string] = CondaEnvFileGenerator(installable_packages)
+            self._conda_env_files[variant_string] = get_conda_file_packages(self._tree, external_deps, variant_start_nodes)
             self._test_feedstocks[variant_string] = []
             for build_command in traverse_build_commands(self._tree, variant_start_nodes):
                 self._test_feedstocks[variant_string].append(build_command.repository)
@@ -558,3 +557,9 @@ def get_installable_packages(build_commands, external_deps, starting_nodes=None,
         if not independent or is_independent(DependencyNode({dep}), build_commands):
             retval = check_and_add({dep}, retval)
     return sorted(retval, key=len)
+
+def get_conda_file_packages(build_commands, external_deps, starting_nodes=None):
+    '''
+    This function makes the conda env file generator for the installable packages.
+    '''
+    return CondaEnvFileGenerator(get_installable_packages(build_commands, external_deps, starting_nodes))

--- a/tests/conda_env_file_generator_test.py
+++ b/tests/conda_env_file_generator_test.py
@@ -77,25 +77,21 @@ def test_conda_env_file_content():
     '''
     Tests that the conda env file content are being populated correctly
     '''
-    packages = build_tree.get_installable_packages(sample_build_commands(), external_deps, starting_nodes=[list(sample_build_commands().nodes)[0]])
-    mock_conda_env_file_generator = conda_env_file_generator.CondaEnvFileGenerator(packages)
+    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), external_deps, starting_nodes=[list(sample_build_commands().nodes)[0]])
     expected_deps = set(["python >=3.6", "pack1 1.0.*", "pack2 >=2.0", "package1a", "package1b",
                          "pack3 9b", "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
-    packages = build_tree.get_installable_packages(sample_build_commands(), [], starting_nodes=[list(sample_build_commands().nodes)[1]])
-    mock_conda_env_file_generator = conda_env_file_generator.CondaEnvFileGenerator(packages)
+    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), [], starting_nodes=[list(sample_build_commands().nodes)[1]])
     expected_deps = set(["python ==3.6.*", "pack1 >=1.0", "pack2 ==2.0.*", "package2a", "pack3 3.3.* build"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
-    packages = build_tree.get_installable_packages(sample_build_commands(), external_deps, starting_nodes=[list(sample_build_commands().nodes)[2]])
-    mock_conda_env_file_generator = conda_env_file_generator.CondaEnvFileGenerator(packages)
+    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), external_deps, starting_nodes=[list(sample_build_commands().nodes)[2]])
     expected_deps = set(["python 3.7.*", "pack1==1.0.*", "pack2 <=2.0", "pack3 3.0.*", "package3a", "package3b",
                      "pack4=1.15.0=py38h6ffa863_0", "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
-    packages = build_tree.get_installable_packages(sample_build_commands(), [], starting_nodes=[list(sample_build_commands().nodes)[3]])
-    mock_conda_env_file_generator = conda_env_file_generator.CondaEnvFileGenerator(packages)
+    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), [], starting_nodes=[list(sample_build_commands().nodes)[3]])
     expected_deps = set(["pack1==1.0.*", "pack2 <=2.0", "pack3-suffix 3.0.*", "package4a", "package4b"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 


### PR DESCRIPTION
We don't need to filter the packages any more. That was added for the packages arg, and when I added the remote packages to the DAG I tried to mimic what it was doing. Turns out I was already handling that with the variant_start_nodes.

@cdeepali I'm glad I looked deeper. This was a problem that just adding the external_deps would have convoluted even more.