### PR TITLE
Add git_location to validate args.

### DIFF
--- a/open_ce/validate_config.py
+++ b/open_ce/validate_config.py
@@ -30,7 +30,8 @@ DESCRIPTION = 'Perform validation on a conda_build_config.yaml file.'
 
 ARGUMENTS = [Argument.CONDA_BUILD_CONFIG, Argument.ENV_FILE,
              Argument.REPOSITORY_FOLDER, Argument.PYTHON_VERSIONS,
-             Argument.BUILD_TYPES, Argument.MPI_TYPES, Argument.CUDA_VERSIONS]
+             Argument.BUILD_TYPES, Argument.MPI_TYPES, Argument.CUDA_VERSIONS,
+             Argument.GIT_LOCATION]
 
 def validate_config(args):
     '''Entry Function'''

--- a/open_ce/validate_env.py
+++ b/open_ce/validate_env.py
@@ -28,7 +28,8 @@ COMMAND = 'env'
 DESCRIPTION = 'Lint Environment Files'
 
 ARGUMENTS = [Argument.ENV_FILE, Argument.PYTHON_VERSIONS,
-             Argument.BUILD_TYPES, Argument.MPI_TYPES, Argument.CUDA_VERSIONS]
+             Argument.BUILD_TYPES, Argument.MPI_TYPES, Argument.CUDA_VERSIONS,
+             Argument.GIT_LOCATION]
 
 def validate_env(args):
     '''Entry Function'''


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?

## Description

Fixes #23 

When the auto conversion of filename to URL was added for env files, the `git_location` arg was assumed to exist here:
https://github.com/open-ce/open-ce-builder/blob/e7e9035e4377c7d71e23add5a8d225c9b739c368/open_ce/inputs.py#L264-L296

But that was not an argument for the validate methods. It has been added.
