### PR TITLE
Handle SystemExit within pool correctly

### DIFF
--- a/open_ce/validate_config.py
+++ b/open_ce/validate_config.py
@@ -62,23 +62,19 @@ def validate_build_tree(tree, external_deps, start_nodes=None):
     '''
     Check a build tree for dependency compatability.
     '''
-    try:
-        packages = [package for recipe in build_tree.traverse_build_commands(tree, start_nodes)
-                                for package in recipe.packages]
-        channels = {channel for recipe in build_tree.traverse_build_commands(tree, start_nodes)
-                                for channel in recipe.channels}
-        env_channels = {channel for node in tree.nodes() for channel in node.channels}
-        deps = build_tree.get_installable_packages(tree, external_deps, start_nodes, True)
+    packages = [package for recipe in build_tree.traverse_build_commands(tree, start_nodes)
+                            for package in recipe.packages]
+    channels = {channel for recipe in build_tree.traverse_build_commands(tree, start_nodes) for channel in recipe.channels}
+    env_channels = {channel for node in tree.nodes() for channel in node.channels}
+    deps = build_tree.get_installable_packages(tree, external_deps, start_nodes, True)
 
-        pkg_args = " ".join(["\"{}\"".format(utils.generalize_version(dep)) for dep in deps
+    pkg_args = " ".join(["\"{}\"".format(utils.generalize_version(dep)) for dep in deps
                                                                     if not utils.remove_version(dep) in packages])
-        channel_args = " ".join({"-c \"{}\"".format(channel) for channel in channels.union(env_channels)})
+    channel_args = " ".join({"-c \"{}\"".format(channel) for channel in channels.union(env_channels)})
 
-        cli = "conda create --dry-run -n test_conda_dependencies {} {}".format(channel_args, pkg_args)
-        ret_code, std_out, std_err = utils.run_command_capture(cli)
-        if not ret_code:
-            raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)
-    except SystemExit as err:
-        raise OpenCEError(Error.ERROR, str(err)) from err
+    cli = "conda create --dry-run -n test_conda_dependencies {} {}".format(channel_args, pkg_args)
+    ret_code, std_out, std_err = utils.run_command_capture(cli)
+    if not ret_code:
+        raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)
 
 ENTRY_FUNCTION = validate_config

--- a/open_ce/validate_config.py
+++ b/open_ce/validate_config.py
@@ -62,19 +62,23 @@ def validate_build_tree(tree, external_deps, start_nodes=None):
     '''
     Check a build tree for dependency compatability.
     '''
-    packages = [package for recipe in build_tree.traverse_build_commands(tree, start_nodes)
-                            for package in recipe.packages]
-    channels = {channel for recipe in build_tree.traverse_build_commands(tree, start_nodes) for channel in recipe.channels}
-    env_channels = {channel for node in tree.nodes() for channel in node.channels}
-    deps = build_tree.get_installable_packages(tree, external_deps, start_nodes, True)
+    try:
+        packages = [package for recipe in build_tree.traverse_build_commands(tree, start_nodes)
+                                for package in recipe.packages]
+        channels = {channel for recipe in build_tree.traverse_build_commands(tree, start_nodes)
+                                for channel in recipe.channels}
+        env_channels = {channel for node in tree.nodes() for channel in node.channels}
+        deps = build_tree.get_installable_packages(tree, external_deps, start_nodes, True)
 
-    pkg_args = " ".join(["\"{}\"".format(utils.generalize_version(dep)) for dep in deps
+        pkg_args = " ".join(["\"{}\"".format(utils.generalize_version(dep)) for dep in deps
                                                                     if not utils.remove_version(dep) in packages])
-    channel_args = " ".join({"-c \"{}\"".format(channel) for channel in channels.union(env_channels)})
+        channel_args = " ".join({"-c \"{}\"".format(channel) for channel in channels.union(env_channels)})
 
-    cli = "conda create --dry-run -n test_conda_dependencies {} {}".format(channel_args, pkg_args)
-    ret_code, std_out, std_err = utils.run_command_capture(cli)
-    if not ret_code:
-        raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)
+        cli = "conda create --dry-run -n test_conda_dependencies {} {}".format(channel_args, pkg_args)
+        ret_code, std_out, std_err = utils.run_command_capture(cli)
+        if not ret_code:
+            raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)
+    except SystemExit as err:
+        raise OpenCEError(Error.ERROR, str(err)) from err
 
 ENTRY_FUNCTION = validate_config

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -440,6 +440,17 @@ def test_build_env_if_no_conda_build(mocker):
     with pytest.raises(OpenCEError):
         opence._main(arg_strings)
 
+def test_system_exit(mocker):
+    '''
+    Test that SystemExit exceptions are handled properly from within pool.
+    '''
+    mocker.patch("open_ce.build_tree.BuildTree._get_repo", side_effect=SystemExit(1))
+
+    arg_strings = ["build", build_env.COMMAND, "tests/test-env1.yaml"]
+    with pytest.raises(OpenCEError) as exc:
+        opence._main(arg_strings)
+    assert "Unexpected Error: 1" in str(exc.value)
+
 def test_run_tests(mocker):
     '''
     Test that the _run_tests function works properly.


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes issue where open-ce-builder will hang if conda_build commands throw a SystemExit from within a worker pool.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
