### PR TITLE
Add Schema Versioning

### DIFF
--- a/doc/README.yaml.md
+++ b/doc/README.yaml.md
@@ -10,6 +10,7 @@
       - [patches](#patches)
       - [channels(feedstock)](#channelsfeedstock)
       - [recipes](#recipes)
+    - [builder_version](#builder_version)
     - [imported_envs](#imported_envs)
     - [channels](#channels)
     - [git_tag_for_env](#git_tag_for_env)
@@ -54,6 +55,7 @@ packages:              # The environment package name
     recipes:           # Sets name and path of recipe location(s)
     patches:           # Specifies list of patches to be applied to this feedstock
     runtime_package:   # Specifies if the package is needed at runtime for the main frameworks to install
+builder_version:       # Specifies the version of builder tools this file is compatible with.
 imported_envs:         # Used to import content of one env file into another
 channels:              # Defines a channel location for obtaining dependencies
 git_tag_for_env:       # Specify a git tag to use across all packages in environment
@@ -201,6 +203,16 @@ If you look in the
 you will see that each of these `path` specifiers has a directory name that is
 present in the feedstock repo, and within each path is a `meta.yaml` file which
 represents the recipe for each separate package.
+
+### builder_version
+
+This keyword specifies the versions of `open-ce-builder` tool this environment file is
+compatible with. This can be used to ensure that there is no schema mismatch
+or incompatibilities. The value can be any valid conda MatchSpec version string.
+
+```yaml
+builder_version: ">=1.0,<3.0"
+```
 
 ### imported_envs
 

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -22,7 +22,7 @@ import shutil
 from open_ce import utils
 from open_ce import __version__ as open_ce_version
 from open_ce.inputs import Argument, parse_arg_list
-from open_ce.errors import OpenCEError, Error
+from open_ce.errors import OpenCEError, Error, show_warning
 
 COMMAND = 'image'
 DESCRIPTION = 'Run Open-CE tools within a container'
@@ -77,7 +77,7 @@ def _get_runtime_image_file(container_tool):
     tool_ver = utils.get_container_tool_ver(container_tool)
     image_file = os.path.join(RUNTIME_IMAGE_PATH, "docker/Dockerfile")
     if not tool_ver:
-        print("WARNING: Could not retrieve version of {} container tool".format(container_tool))
+        show_warning(Error.CONTAINER_VERSION, container_tool)
         # If we couldn't get the version of the tool, should use the older docker
         # supported Dockerfile
         return image_file

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -142,7 +142,6 @@ def version_matches_spec(spec_string, version=open_ce_version):
     version_matches_spec(">=1.2,<1.3", "1.2.1") -> True
     version_matches_spec(">=1.2,<1.3", "1.3.0") -> False
     '''
-    print(version)
     match_spec = MatchSpec("test[version='{}']".format(spec_string))
     query_pkg = {"name": "test", "version": version, "build": "", "build_number": 0}
     return match_spec.match(query_pkg)

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -26,6 +26,7 @@ import functools
 from open_ce.utils import validate_dict_schema, check_if_package_exists, generalize_version # pylint: disable=cyclic-import
 from open_ce.errors import OpenCEError, Error
 import open_ce.yaml_utils
+from open_ce import __version__ as open_ce_version
 
 check_if_package_exists('conda-build')
 
@@ -34,6 +35,7 @@ import conda_build.api
 from conda_build.config import get_or_merge_config
 import conda_build.metadata
 import conda.cli.python_api
+from conda.models.match_spec import MatchSpec
 # pylint: enable=wrong-import-position,wrong-import-order
 
 def render_yaml(path, variants=None, variant_config_files=None, schema=None, permit_undefined_jinja=False):
@@ -132,3 +134,8 @@ def get_latest_package_info(channels, package):
         if package_info["timestamp"] > retval["timestamp"]:
             retval = package_info
     return retval
+
+def version_matches_spec(spec_string, version=open_ce_version):
+    match_spec = MatchSpec("test[version='{}']".format(spec_string))
+    query_pkg = {"name": "test", "version": version, "build": "", "build_number": 0}
+    return match_spec.match(query_pkg)

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -136,6 +136,13 @@ def get_latest_package_info(channels, package):
     return retval
 
 def version_matches_spec(spec_string, version=open_ce_version):
+    '''
+    Uses conda version specification syntax to check if version matches spec_string.
+    e.g.
+    version_matches_spec(">=1.2,<1.3", "1.2.1") -> True
+    version_matches_spec(">=1.2,<1.3", "1.3.0") -> False
+    '''
+    print(version)
     match_spec = MatchSpec("test[version='{}']".format(spec_string))
     query_pkg = {"name": "test", "version": version, "build": "", "build_number": 0}
     return match_spec.match(query_pkg)

--- a/open_ce/env_config.py
+++ b/open_ce/env_config.py
@@ -20,7 +20,8 @@ import os
 from enum import Enum, unique, auto
 
 from open_ce import utils
-from open_ce.errors import OpenCEError, Error
+from open_ce.errors import OpenCEError, Error, show_warning
+from open_ce import __version__ as open_ce_version
 
 @unique
 class Key(Enum):
@@ -71,9 +72,12 @@ def _validate_config_file(env_file, variants):
         version_check_obj = conda_utils.render_yaml(env_file, permit_undefined_jinja=True)
         if Key.builder_version.name in version_check_obj.keys():
             if not conda_utils.version_matches_spec(version_check_obj.get(Key.builder_version.name)):
-                raise OpenCEError(Error.ERROR, "Version mismatch.")
+                raise OpenCEError(Error.SCHEMA_VERSION_MISMATCH,
+                                  env_file,
+                                  version_check_obj.get(Key.builder_version.name),
+                                  open_ce_version)
         else:
-            print("WARNING: '{}' does not provide '{}'. Possible schema mismatch.".format(env_file, Key.builder_version.name))
+            show_warning(Error.SCHEMA_VERSION_NOT_FOUND, env_file, Key.builder_version.name)
 
         meta_obj = conda_utils.render_yaml(env_file, variants=variants, schema=_ENV_CONFIG_SCHEMA)
         if not (Key.packages.name in meta_obj.keys() or Key.imported_envs.name in meta_obj.keys()):

--- a/open_ce/env_config.py
+++ b/open_ce/env_config.py
@@ -76,13 +76,17 @@ def _validate_config_file(env_file, variants):
                                   env_file,
                                   version_check_obj.get(Key.builder_version.name),
                                   open_ce_version)
-        else:
-            show_warning(Error.SCHEMA_VERSION_NOT_FOUND, env_file, Key.builder_version.name)
 
-        meta_obj = conda_utils.render_yaml(env_file, variants=variants, schema=_ENV_CONFIG_SCHEMA)
-        if not (Key.packages.name in meta_obj.keys() or Key.imported_envs.name in meta_obj.keys()):
-            raise OpenCEError(Error.CONFIG_CONTENT)
-        meta_obj[Key.opence_env_file_path.name] = env_file
+        meta_obj = None
+        try:
+            meta_obj = conda_utils.render_yaml(env_file, variants=variants, schema=_ENV_CONFIG_SCHEMA)
+            if not (Key.packages.name in meta_obj.keys() or Key.imported_envs.name in meta_obj.keys()):
+                raise OpenCEError(Error.CONFIG_CONTENT)
+            meta_obj[Key.opence_env_file_path.name] = env_file
+        except OpenCEError as exc:
+            if Key.builder_version.name not in version_check_obj.keys():
+                show_warning(Error.SCHEMA_VERSION_NOT_FOUND, env_file, Key.builder_version.name)
+            raise exc
         return meta_obj
     except (Exception, SystemExit) as exc: #pylint: disable=broad-except
         raise OpenCEError(Error.ERROR, "Error in {}:\n  {}".format(env_file, str(exc))) from exc

--- a/open_ce/errors.py
+++ b/open_ce/errors.py
@@ -16,11 +16,12 @@
 # *****************************************************************
 """
 
+import sys
 from enum import Enum, unique
 
 @unique
 class Error(Enum):
-    '''Enum for Arguments'''
+    '''Enum for Error Messages'''
     ERROR = (0, "Unexpected Error: {}")
     CREATE_CONTAINER = (1, "Error creating container: \"{}\"")
     COPY_DIR_TO_CONTAINER = (2, "Error copying \"{}\" directory into container: \"{}\"")
@@ -57,6 +58,13 @@ class Error(Enum):
     NO_CONTAINER_TOOL_FOUND = (27, "No container tool found on the system.")
     CONDA_PACKAGE_INFO = (28, "Conda Package Info Failed.\nCommand:\n{}\nOutput:\n{}")
     REMOTE_PACKAGE_DEPENDENCIES = (29, "Failure getting remote dependencies for the following packages:\n{}\nError:\n{}")
+    WARNING = (30, "Unexpected Warning: {}")
+    SCHEMA_VERSION_NOT_FOUND = (31, "'{}' does not provide '{}'. Possible schema mismatch.")
+    CONTAINER_VERSION = (32, "Could not retrieve version of {} container tool.")
+    CONDA_BUILD_CONFIG_NOT_FOUND = (33, "No valid '{}' file was found. Some recipes may fail to build.")
+    CONDA_IO_ERROR = (34, "IO error occurred while reading version information from conda environment file '{}'.")
+    SCHEMA_VERSION_MISMATCH = (35, "Open-CE Env file '{}' expects to be built with Open-CE Builder [{}]. " +
+                                    "But this version is '{}'.")
 
 class OpenCEError(Exception):
     """
@@ -70,3 +78,10 @@ class OpenCEError(Exception):
             msg = "[OPEN-CE-ERROR-{}] {}".format(error.value[0], error.value[1].format(*additional_args))
         super().__init__(msg, **kwargs)
         self.msg = msg
+
+def show_warning(warning, *additional_args, file=sys.stderr, **kwargs):
+    """
+    Prints an Open-CE Warning.
+    """
+    msg = "[OPEN-CE-WARNING-{}] {}".format(warning.value[0], warning.value[1].format(*additional_args))
+    print(msg, file=file, **kwargs)

--- a/open_ce/inputs.py
+++ b/open_ce/inputs.py
@@ -21,6 +21,7 @@ import os
 import argparse
 from enum import Enum, unique
 from open_ce import utils
+from open_ce.errors import Error, show_warning
 
 class OpenCEFormatter(argparse.ArgumentDefaultsHelpFormatter):
     """
@@ -320,7 +321,7 @@ def parse_args(parser, arg_strings=None):
         elif os.path.exists(args.conda_build_config):
             args.conda_build_config = os.path.abspath(args.conda_build_config)
         else:
-            print("WARNING: No valid conda_build_config.yaml file was found. Some recipes may fail to build.")
+            show_warning(Error.CONDA_BUILD_CONFIG_NOT_FOUND, utils.CONDA_BUILD_CONFIG_FILE)
 
     return args
 

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -26,7 +26,7 @@ import urllib.request
 import tempfile
 import multiprocessing as mp
 import pkg_resources
-from open_ce.errors import OpenCEError, Error
+from open_ce.errors import OpenCEError, Error, show_warning
 from open_ce import inputs
 
 
@@ -351,7 +351,7 @@ def get_open_ce_version(conda_env_file):
                     break
 
     except IOError:
-        print("WARNING: IO error occurred while reading version information from conda environment file.")
+        show_warning(Error.CONDA_IO_ERROR, conda_env_file)
     finally:
         if conda_file:
             conda_file.close()

--- a/tests/test-env3.yaml
+++ b/tests/test-env3.yaml
@@ -14,6 +14,8 @@
 # limitations under the License.
 # *****************************************************************
 
+builder_version: ">=1"
+
 packages:
     - feedstock : package21 #[python == '2.1']
     - feedstock : package211

--- a/tests/validate_env_test.py
+++ b/tests/validate_env_test.py
@@ -29,28 +29,27 @@ spec.loader.exec_module(opence)
 import open_ce.validate_env as validate_env
 from open_ce.errors import OpenCEError
 
-def test_validate_env(mocker, capsys):
+def test_validate_env():
     '''
     Positive test for validate_env.
+    '''
+    env_file = os.path.join(test_dir, 'test-env2.yaml')
+    opence._main(["validate", validate_env.COMMAND, env_file])
+
+def test_validate_env_negative(mocker, capsys):
+    '''
+    Negative test for validate_env.
     '''
     from sys import stderr
     # Apparently the `file` default was being set before capsys mocked sys.stderr. This mocks the default for the function.
     mocker.patch('open_ce.errors.show_warning.__kwdefaults__', {'file': stderr})
-    env_file = os.path.join(test_dir, 'test-env2.yaml')
-    opence._main(["validate", validate_env.COMMAND, env_file])
-    captured = capsys.readouterr()
-    assert "OPEN-CE-WARNING" in captured.err
-    assert "test-env2.yaml' does not provide 'builder_version'. Possible schema mismatch." in captured.err
-    assert "test-env1.yaml' does not provide 'builder_version'. Possible schema mismatch." in captured.err
-
-def test_validate_env_negative():
-    '''
-    Negative test for validate_env.
-    '''
     env_file = os.path.join(test_dir, 'test-env-invalid1.yaml')
     with pytest.raises(OpenCEError) as exc:
         opence._main(["validate", validate_env.COMMAND, env_file])
     assert "Unexpected key chnnels was found in " in str(exc.value)
+    captured = capsys.readouterr()
+    assert "OPEN-CE-WARNING" in captured.err
+    assert "test-env-invalid1.yaml' does not provide 'builder_version'. Possible schema mismatch." in captured.err
 
 def test_validate_env_wrong_external_deps(mocker,):
     '''


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes #32 

Uses the `MatchSpec` class from conda so that we can use conda version strings to specify the builder version.

Still need to add actual error message, tests and update the docs.

The env file can look something like:
```
builder_version: >=1.4.0,<1.5.0

packages:
  - feedstock : cdts
    runtime_package : False
  - feedstock : bazel
    runtime_package : False
```
