### PR TITLE
Add version to help.

### DIFF
--- a/open_ce/inputs.py
+++ b/open_ce/inputs.py
@@ -22,6 +22,7 @@ import argparse
 from enum import Enum, unique
 from open_ce import utils
 from open_ce.errors import Error, show_warning
+from open_ce import __version__ as open_ce_version
 
 class OpenCEFormatter(argparse.ArgumentDefaultsHelpFormatter):
     """
@@ -243,6 +244,12 @@ path of \"recipe\"."""))
                                      default=None,
                                      help="Comma delimited list of template files to initialize with Open-CE "
                                           " information."))
+
+    VERSION = (lambda parser: parser.add_argument(
+                                     '-v',
+                                     '--version',
+                                     action='version',
+                                     version="Open-CE Builder {}".format(open_ce_version)))
 
 
 def make_parser(arguments, *args, formatter_class=OpenCEFormatter, **kwargs):

--- a/open_ce/open-ce
+++ b/open_ce/open-ce
@@ -33,7 +33,7 @@ from open_ce import __version__ as open_ce_version
 #pylint: disable=too-many-locals
 def make_parser():
     ''' Parser for input arguments '''
-    parser = inputs.make_parser([], description = 'Open-CE Builder {}'.format(open_ce_version))
+    parser = inputs.make_parser([inputs.Argument.VERSION], description = 'Open-CE Builder {}'.format(open_ce_version))
 
     subparsers = parser.add_subparsers(title='Open-CE Commands',
                                        description='Choose from the following commands to perform.')

--- a/open_ce/open-ce
+++ b/open_ce/open-ce
@@ -28,11 +28,12 @@ from open_ce import validate_config
 from open_ce import validate_env
 from open_ce import build_image
 from open_ce import get_licenses
+from open_ce import __version__ as open_ce_version
 
 #pylint: disable=too-many-locals
 def make_parser():
     ''' Parser for input arguments '''
-    parser = inputs.make_parser([], description = 'Open-CE Tool')
+    parser = inputs.make_parser([], description = 'Open-CE Builder {}'.format(open_ce_version))
 
     subparsers = parser.add_subparsers(title='Open-CE Commands',
                                        description='Choose from the following commands to perform.')


### PR DESCRIPTION
Since a user may need to know the version, we should have it readily available in the help message. I didn't think to add this as part of #33 

```
(dev) [bnelson@dlw05 open-ce-builder]$ open-ce -h
usage: open-ce [-h] {build,test,validate,get} ...

Open-CE Builder 3.0.0

optional arguments:
  -h, --help            show this help message and exit

Open-CE Commands:
  Choose from the following commands to perform.

  {build,test,validate,get}
    build               Build a feedstock, an image, or an environment.
    test                Run tests within a feedstock.
    validate            Validate an env file or a conda_build_config file.
    get                 Get information about Open-CE builds.
```