### PR TITLE
Add build string to packages in conda environment files

### DIFF
--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -516,6 +516,9 @@ def get_installable_packages(build_commands, external_deps, starting_nodes=None,
     This function retrieves the list of unique dependencies that are needed at runtime, from the
     build commands and external dependencies that are passed to it.
     '''
+    #pylint: disable=import-outside-toplevel
+    from open_ce import conda_utils
+
     retval =  set()
 
     def check_matching(deps_set, dep_to_be_added):
@@ -568,9 +571,9 @@ def get_installable_packages(build_commands, external_deps, starting_nodes=None,
                 run_deps = build_command.run_dependencies
             retval = check_and_add(run_deps, retval)
             if not independent:
-                retval = check_and_add([package + (" " + build_command.version[i] if build_command.version else "")
-                                                        for i, package in enumerate(build_command.packages)],
-                                                    retval)
+                retval = check_and_add([conda_utils.output_file_to_string(output_file)
+                                            for output_file in build_command.output_files],
+                                       retval)
 
     for dep in external_deps:
         if not independent or is_independent(DependencyNode({dep}), build_commands):

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -145,3 +145,11 @@ def version_matches_spec(spec_string, version=open_ce_version):
     match_spec = MatchSpec("test[version='{}']".format(spec_string))
     query_pkg = {"name": "test", "version": version, "build": "", "build_number": 0}
     return match_spec.match(query_pkg)
+
+def output_file_to_string(output_file):
+    '''
+    Given a package file name,
+    returns a string that can be used within a conda environment file to reference the package specifically.
+    '''
+    match_spec = MatchSpec.from_dist_str(os.path.basename(output_file))
+    return "{} {} {}".format(match_spec.get("name", ""), match_spec.get("version", ""), match_spec.get("build", "")).strip()

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -542,15 +542,18 @@ def test_get_installable_package_with_no_duplicates():
                                                                                                     "repo1",
                                                                                                     ["package1a"],
                                                                                                     runtime_package=False,
+                                                                                                    output_files=["package1a-1.0-py37_4.tar.bz2"],
                                                                                                     run_dependencies=["python 3.7", "pack1a==1.0"]))
     node2 = build_tree.DependencyNode(packages=["package2a"], build_command=build_tree.BuildCommand("recipe2",
                                                                                                     "repo2",
                                                                                                     ["package2a"],
+                                                                                                    output_files=["package2a-2.0-py37.tar.bz2"],
                                                                                                     run_dependencies=["python 3.7", "pack1 ==1.0", "pack1", "pack2 <=2.0",
                                                                                                     "pack2 2.0", "pack3   3.0.*", "pack2"]))
     node3 = build_tree.DependencyNode(packages=["package3a", "package3b"], build_command=build_tree.BuildCommand("recipe3",
                                                                                                                 "repo3",
                                                                                                                 ["package3a", "package3b"],
+                                                                                                                output_files=["package3a-1.5-cpu.tar.bz2", "package3b-1.5-cpu.tar.bz2"],
                                                                                                                 run_dependencies=["pack1 >=1.0", "pack1", "pack4 <=2.0",
                                                                                                                 "pack2 2.0", "pack3   3.0.*", "pack4"]))
 
@@ -562,13 +565,13 @@ def test_get_installable_package_with_no_duplicates():
     for dep in external_deps:
         build_commands.add_node(build_tree.DependencyNode({dep}))
     packages = build_tree.get_installable_packages(build_commands, external_deps)
-    assert not "package1a" in packages
-    assert not "pack1a" in packages
+    assert not "package1a" in str(packages)
+    assert not "pack1a" in str(packages)
 
     print("Packages: ", packages)
 
-    expected_packages = ["package2a", "python 3.7.*", "pack1 ==1.0.*", "pack2 <=2.0", "pack3 3.0.*",
-                         "package3a", "package3b", "pack4 <=2.0", "external_pac1 1.2.*"]
+    expected_packages = ["package2a 2.0.* py37", "python 3.7.*", "pack1 ==1.0.*", "pack2 <=2.0", "pack3 3.0.*",
+                         "package3a 1.5.* cpu", "package3b 1.5.* cpu", "pack4 <=2.0", "external_pac1 1.2.*"]
     assert Counter(packages) == Counter(expected_packages)
 
 def test_get_build_copmmand_dependencies():

--- a/tests/conda_env_file_generator_test.py
+++ b/tests/conda_env_file_generator_test.py
@@ -36,6 +36,7 @@ def sample_build_commands() :
                                                                                                     build_type="cuda",
                                                                                                     mpi_type="openmpi",
                                                                                                     cudatoolkit="10.2",
+                                                                                                    output_files=["package1a-1.0-py36_cuda10.2.tar.bz2", "package1b-1.0-py36_cuda10.2.tar.bz2"],
                                                                                                     run_dependencies=["python     >=3.6", "pack1    1.0", "pack2   >=2.0", "pack3 9b"]))
     node2 = build_tree.DependencyNode(packages=["package2a"], build_command=build_tree.BuildCommand("recipe2",
                                                                                                     "repo2",
@@ -44,6 +45,7 @@ def sample_build_commands() :
                                                                                                     build_type="cpu",
                                                                                                     mpi_type="system",
                                                                                                     cudatoolkit="10.2",
+                                                                                                    output_files=["package2a-1.0-py36_cuda10.2.tar.bz2"],
                                                                                                     run_dependencies=["python ==3.6", "pack1 >=1.0", "pack2   ==2.0", "pack3 3.3 build"]))
     node3 = build_tree.DependencyNode(packages=["package3a", "package3b"], build_command=build_tree.BuildCommand("recipe3",
                                                                                                     "repo3",
@@ -52,6 +54,7 @@ def sample_build_commands() :
                                                                                                     build_type="cpu",
                                                                                                     mpi_type="openmpi",
                                                                                                     cudatoolkit="10.2",
+                                                                                                    output_files=["package3a-1.0-py37_cuda10.2.tar.bz2", "package3b-1.0-py37_cuda10.2.tar.bz2"],
                                                                                                     run_dependencies=["python 3.7", "pack1==1.0", "pack2 <=2.0", "pack3   3.0.*",
                                                                                                                     "pack4=1.15.0=py38h6ffa863_0"]))
     node4 = build_tree.DependencyNode(packages=["package4a", "package4b"], build_command=build_tree.BuildCommand("recipe4",
@@ -61,6 +64,7 @@ def sample_build_commands() :
                                                                                                     build_type="cuda",
                                                                                                     mpi_type="system",
                                                                                                     cudatoolkit="10.2",
+                                                                                                    output_files=["package4a-1.0-py37_cuda10.2.tar.bz2", "package4b-1.0-py37_cuda10.2.tar.bz2"],
                                                                                                     run_dependencies=["pack1==1.0", "pack2 <=2.0", "pack3-suffix 3.0"]))
 
     retval.add_node(node1)
@@ -78,21 +82,21 @@ def test_conda_env_file_content():
     Tests that the conda env file content are being populated correctly
     '''
     mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), external_deps, starting_nodes=[list(sample_build_commands().nodes)[0]])
-    expected_deps = set(["python >=3.6", "pack1 1.0.*", "pack2 >=2.0", "package1a", "package1b",
+    expected_deps = set(["python >=3.6", "pack1 1.0.*", "pack2 >=2.0", "package1a 1.0.* py36_cuda10.2", "package1b 1.0.* py36_cuda10.2",
                          "pack3 9b", "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
     mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), [], starting_nodes=[list(sample_build_commands().nodes)[1]])
-    expected_deps = set(["python ==3.6.*", "pack1 >=1.0", "pack2 ==2.0.*", "package2a", "pack3 3.3.* build"])
+    expected_deps = set(["python ==3.6.*", "pack1 >=1.0", "pack2 ==2.0.*", "package2a 1.0.* py36_cuda10.2", "pack3 3.3.* build"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
     mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), external_deps, starting_nodes=[list(sample_build_commands().nodes)[2]])
-    expected_deps = set(["python 3.7.*", "pack1==1.0.*", "pack2 <=2.0", "pack3 3.0.*", "package3a", "package3b",
+    expected_deps = set(["python 3.7.*", "pack1==1.0.*", "pack2 <=2.0", "pack3 3.0.*", "package3a 1.0.* py37_cuda10.2", "package3b 1.0.* py37_cuda10.2",
                      "pack4=1.15.0=py38h6ffa863_0", "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
     mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), [], starting_nodes=[list(sample_build_commands().nodes)[3]])
-    expected_deps = set(["pack1==1.0.*", "pack2 <=2.0", "pack3-suffix 3.0.*", "package4a", "package4b"])
+    expected_deps = set(["pack1==1.0.*", "pack2 <=2.0", "pack3-suffix 3.0.*", "package4a 1.0.* py37_cuda10.2", "package4b 1.0.* py37_cuda10.2"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
 def test_create_channels():

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -140,4 +140,4 @@ def mock_renderer(path, package_deps):
     return make_render_result(package, package_deps[package])
 
 def mock_get_output_file_paths(meta):
-    return [meta.meta['package']['name'] + meta.meta['build']['string']]
+    return [meta.meta['package']['name'] + "-" + meta.meta['package']['version'] + "-" + meta.meta['build']['string'] + ".tar.bz2"]


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

The pyarrow package doesn't have meta packages with different names for choosing cpu and cuda builds. Instead, it relies on the information in the build string for picking the correct package. Because of this, the conda environment files that we are currently generating always pick the default build type.

This PR adds the build strings to the generated packages listed in the conda environment files, which will allow for the correct version of pyarrow to be selected.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
