### PR TITLE
Use single quotes when combining conda_build_configs

### DIFF
--- a/open_ce/build_command.py
+++ b/open_ce/build_command.py
@@ -83,7 +83,7 @@ class BuildCommand():
         if self.cudatoolkit:
             build_args += ["--cuda_versions", self.cudatoolkit]
         if self.conda_build_configs:
-            build_args += ["--conda_build_configs", "\"" + ",".join(self.conda_build_configs) + "\""]
+            build_args += ["--conda_build_configs", "\'" + ",".join(self.conda_build_configs) + "\'"]
 
         if self.recipe:
             build_args += ["--recipes", self.recipe]

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -174,7 +174,7 @@ def test_feedstock_args():
         if build_command.cudatoolkit:
             assert "--cuda_versions {}".format(build_command.cudatoolkit) in build_string
         if build_command.conda_build_configs:
-            assert "--conda_build_configs \"{}\"".format(",".join(build_command.conda_build_configs)) in build_string
+            assert "--conda_build_configs \'{}\'".format(",".join(build_command.conda_build_configs)) in build_string
 
 def test_clone_repo(mocker):
     '''


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

When printing out the conda_build_configs using the `feedstock_args` method, use single quotes instead of double quotes.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
