### PR TITLE
Use conda_build_configs in create_version_branch

### DIFF
--- a/git_tools/create_version_branch.py
+++ b/git_tools/create_version_branch.py
@@ -109,8 +109,8 @@ def _create_version_branch(arg_strings=None):# pylint: disable=too-many-branches
         git_utils.checkout(repo_path, args.commit)
     current_commit = git_utils.get_current_branch(repo_path)
     config_file = None
-    if args.conda_build_config:
-        config_file = [args.conda_build_config]
+    if args.conda_build_configs:
+        config_file = args.conda_build_configs
     try:
         git_utils.checkout(repo_path, "HEAD~")
         previous_version = _get_repo_version(repo_path, config_file)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

The create_version_branch was still referring to `args.conda_build_config` instead of `args.conda_build_configs`.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
