### PR TITLE
Remove cudatoolkit version from CPU build_types

### DIFF
--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -200,8 +200,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                 self._tree = networkx.compose(self._tree, variant_tree)
             except OpenCEError as exc:
                 raise OpenCEError(Error.CREATE_BUILD_TREE, exc.msg) from exc
-            variant_string = utils.variant_string(variant["python"], variant["build_type"],
-                                                  variant["mpi_type"], variant["cudatoolkit"])
+            variant_string = utils.variant_string(variant.get("python"), variant.get("build_type"),
+                                                  variant.get("mpi_type"), variant.get("cudatoolkit"))
             self._external_dependencies[variant_string] = external_deps
 
             self._detect_cycle()
@@ -412,8 +412,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
     def get_external_dependencies(self, variant):
         '''Return the list of external dependencies for the given variant.'''
-        variant_string = utils.variant_string(variant["python"], variant["build_type"],
-                                              variant["mpi_type"], variant["cudatoolkit"])
+        variant_string = utils.variant_string(variant.get("python"), variant.get("build_type"),
+                                              variant.get("mpi_type"), variant.get("cudatoolkit"))
         return self._external_dependencies.get(variant_string, [])
 
     def write_conda_env_files(self,
@@ -505,13 +505,13 @@ def _create_commands(repository, runtime_package, recipe_path,
                                     repository=repository,
                                     packages=packages,
                                     version=version,
-                                    recipe_path=recipe_path,
+                                    recipe_path=recipe.get('path'),
                                     runtime_package=runtime_package,
                                     output_files=output_files,
-                                    python=variants['python'],
-                                    build_type=variants['build_type'],
-                                    mpi_type=variants['mpi_type'],
-                                    cudatoolkit=variants['cudatoolkit'],
+                                    python=variants.get('python'),
+                                    build_type=variants.get('build_type'),
+                                    mpi_type=variants.get('mpi_type'),
+                                    cudatoolkit=variants.get('cudatoolkit'),
                                     run_dependencies=run_deps,
                                     host_dependencies=host_deps,
                                     build_dependencies=build_deps,

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -59,11 +59,16 @@ OPEN_CE_VERSION_STRING = "Open-CE Version"
 def make_variants(python_versions=DEFAULT_PYTHON_VERS, build_types=DEFAULT_BUILD_TYPES, mpi_types=DEFAULT_MPI_TYPES,
 cuda_versions=DEFAULT_CUDA_VERS):
     '''Create a cross product of possible variant combinations.'''
-    variants = { 'python' : inputs.parse_arg_list(python_versions),
-                 'build_type' : inputs.parse_arg_list(build_types),
-                 'mpi_type' :  inputs.parse_arg_list(mpi_types),
-                 'cudatoolkit' : inputs.parse_arg_list(cuda_versions)}
-    return [dict(zip(variants,y)) for y in product(*variants.values())]
+    results = []
+    for build_type in inputs.parse_arg_list(build_types):
+        variants = { 'python' : inputs.parse_arg_list(python_versions),
+                     'build_type' : [build_type],
+                     'mpi_type' :  inputs.parse_arg_list(mpi_types)}
+        if build_type == "cuda":
+            variants["cudatoolkit"] = inputs.parse_arg_list(cuda_versions)
+        results += [dict(zip(variants,y)) for y in product(*variants.values())]
+
+    return results
 
 def remove_version(package):
     '''Remove conda version from dependency.'''
@@ -156,8 +161,9 @@ def variant_string_to_dict(var_string):
     variants = var_string.split("-")
     variant_dict = { 'python' : variants[0][2:],
                      'build_type' : variants[1],
-                     'mpi_type' : variants[2],
-                     'cudatoolkit' : variants[3] }
+                     'mpi_type' : variants[2] }
+    if variant_dict["build_type"] == "cuda":
+        variant_dict["cudatoolkit"] = variants[3]
 
     return variant_dict
 

--- a/open_ce/validate_config.py
+++ b/open_ce/validate_config.py
@@ -48,10 +48,10 @@ def validate_env_config(conda_build_config, env_config_files, variants, reposito
             print('Validating {} for {} : {}'.format(conda_build_config, env_file, variant))
             try:
                 _ = build_tree.BuildTree([env_file],
-                                          variant['python'],
-                                          variant['build_type'],
-                                          variant['mpi_type'],
-                                          variant['cudatoolkit'],
+                                          variant.get('python'),
+                                          variant.get('build_type'),
+                                          variant.get('mpi_type'),
+                                          variant.get('cudatoolkit'),
                                           repository_folder=repository_folder,
                                           conda_build_config=conda_build_config)
             except OpenCEError as err:

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -231,8 +231,8 @@ def test_build_env(mocker, capsys):
     )
 
     env_file = os.path.join(test_dir, 'test-env2.yaml')
-    opence._main(["build", build_env.COMMAND, env_file, "--cuda_versions", cuda_version])
-    validate_and_remove_conda_env_files(cuda_versions=cuda_version)
+    opence._main(["build", build_env.COMMAND, env_file, "--cuda_versions", cuda_version, "--build_types", "cuda"])
+    validate_and_remove_conda_env_files(build_types="cuda", cuda_versions=cuda_version)
 
     #---The seventh test specifies specific packages that should be built (plus their dependencies)
     package_deps = {"package11": ["package15"],
@@ -301,7 +301,7 @@ def validate_and_remove_conda_env_files(py_versions=utils.DEFAULT_PYTHON_VERS,
     for variant in variants:
         cuda_env_file = os.path.join(os.getcwd(), utils.DEFAULT_OUTPUT_FOLDER,
                                      "{}{}.yaml".format(utils.CONDA_ENV_FILENAME_PREFIX,
-                                     utils.variant_string(variant['python'], variant['build_type'], variant['mpi_type'], variant['cudatoolkit'])))
+                                     utils.variant_string(variant.get('python'), variant.get('build_type'), variant.get('mpi_type'), variant.get('cudatoolkit'))))
         assert os.path.exists(cuda_env_file)
         # Remove the file once it's existence is verified
         os.remove(cuda_env_file)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Only set the `cudatoolkit` variant if the `build_type` is "cuda". This will cut down on a bit of work, and make sure the cudatoolkit value doesn't get added to the outputfile's hash string.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
