### PR TITLE
[git_tools] Fix tag_repos script with existing tag arg.

### DIFF
--- a/git_tools/tag_all_repos.py
+++ b/git_tools/tag_all_repos.py
@@ -93,8 +93,9 @@ def tag_all_repos(github_org, tag, tag_msg, branch, repo_dir, pat, skipped_repos
             git_utils.checkout(repo_path, branch)
         elif prev_tag:
             repo_branch = git_utils.get_tag_branch(repo_path, prev_tag)
-            print("--->Checking out branch '{}' which contains tag '{}'.".format(repo_branch, prev_tag))
-            git_utils.checkout(repo_path, repo_branch)
+            if git_utils.branch_exists(repo_path, repo_branch):
+                print("--->Checking out branch '{}' which contains tag '{}'.".format(repo_branch, prev_tag))
+                git_utils.checkout(repo_path, repo_branch)
 
     print("---------------------------Tagging all Repos")
     for repo in repos:


### PR DESCRIPTION
Only try to checkout `previous_tag` arg branch if it exists. Otherwise just stay in default branch.