### PR TITLE
Add ssh to Dockerfile for openmpi tests

### DIFF
--- a/open_ce/images/builder-cuda-ppc64le/Dockerfile.cuda-10.2
+++ b/open_ce/images/builder-cuda-ppc64le/Dockerfile.cuda-10.2
@@ -15,7 +15,7 @@ ARG BUILD_ID=1084
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y rsync && \
+    yum repolist && yum install -y rsync openssh-clients && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder

--- a/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-10.2
+++ b/open_ce/images/builder-cuda-x86_64/Dockerfile.cuda-10.2
@@ -15,7 +15,7 @@ ARG BUILD_ID=1084
 RUN rpm -e --nodeps --verbose gcc gcc-c++
 
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y rsync && \
+    yum repolist && yum install -y rsync openssh-clients && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder


### PR DESCRIPTION
Openmpi performs a self test during build time that requires ssh to be
installed.  If it is not available, an error like the one below may
occur for cuda 10.2 versions of mpi
--------------------------------------------------------------------------
The value of the MCA parameter "plm_rsh_agent" was set to a path
that could not be found:
  plm_rsh_agent: ssh : rsh
Please either unset the parameter, or check that the path is correct
--------------------------------------------------------------------------

## Checklist before submitting

- [ X] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ X] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
