### PR TITLE
Remove matplotlib as pip depenedency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The `open-ce` tool allows a user to build collections of conda recipes described
 * `python` >= 3.6
 * `docker` >= 1.13 or `podman` >= 2.0.5
   * docker or podman required only when building within a container (see below).
+* `matplotlib` >= 3.3
+  * Required only when exporting the dependency graph.
 
 ### CUDA Requirements
 
@@ -147,4 +149,3 @@ After performing the build using `open-ce build env`, the `open-ce build image` 
 ### Contributions
 
 For contribution information, please see the [CONTRIBUTING.md](CONTRIBUTING.md) page.
-

--- a/open_ce/errors.py
+++ b/open_ce/errors.py
@@ -65,6 +65,8 @@ class Error(Enum):
     CONDA_IO_ERROR = (34, "IO error occurred while reading version information from conda environment file '{}'.")
     SCHEMA_VERSION_MISMATCH = (35, "Open-CE Env file '{}' expects to be built with Open-CE Builder [{}]. " +
                                     "But this version is '{}'.")
+    PACKAGE_NOT_FOUND = (36, "Cannot find `{}`, please see https://github.com/open-ce/open-ce-builder#requirements" +
+                             " for a list of requirements.")
 
 class OpenCEError(Exception):
     """

--- a/open_ce/graph.py
+++ b/open_ce/graph.py
@@ -17,7 +17,7 @@
 """
 
 import networkx as nx
-import matplotlib.pyplot as plt
+from open_ce.utils import check_if_package_exists
 
 class OpenCEGraph(nx.DiGraph):
     """
@@ -84,6 +84,8 @@ def export_image(graph, output_file, x=50, y=50):
     '''
     Export a plot of a graph using matplotlib.
     '''
+    check_if_package_exists('matplotlib')
+    import matplotlib.pyplot as plt # pylint: disable=import-outside-toplevel
     f = plt.figure()
     f.set_figwidth(x)
     f.set_figheight(y)

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -17,7 +17,6 @@
 """
 
 import os
-import sys
 import subprocess
 import errno
 from itertools import product
@@ -76,13 +75,11 @@ def remove_version(package):
     return package.split()[0].split("=")[0]
 
 def check_if_package_exists(package):
-    '''Checks if conda-build is installed and exits if it is not'''
+    '''Checks if a package is installed'''
     try:
         pkg_resources.get_distribution(package)
-    except pkg_resources.DistributionNotFound:
-        print("Cannot find `{}`, please see https://github.com/open-ce/open-ce-builder#requirements"
-              " for a list of requirements.".format(package))
-        sys.exit(1)
+    except pkg_resources.DistributionNotFound as exc:
+        raise OpenCEError(Error.PACKAGE_NOT_FOUND, package) from exc
 
 def make_schema_type(data_type,required=False):
     '''Make a schema type tuple.'''

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ REQUIRED_PACKAGES = [
     "requests",
     "jinja2",
     "networkx",
-    "matplotlib",
+    #"matplotlib", broken on ppc
 ]
 
 setup(


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?

## Description

`matplotlib` can't be installed with pip on ppc. This PR removes the pip dependency and adds a check for it.
