### PR TITLE
Reduce Argo Dependencies

### DIFF
--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -235,6 +235,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         # Execute validate_build_tree in parallel
         utils.run_in_parallel(validate_config.validate_build_tree, validate_args)
 
+        self.remove_external_deps_from_dag()
+
     def _get_repo(self, env_config_data, package):
         # If the feedstock value starts with any of the SUPPORTED_GIT_PROTOCOLS, treat it as a url. Otherwise
         # combine with git_location and append "-feedstock.git"
@@ -458,7 +460,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         '''
         Can be used to get the name of all a node's dependencies.
         '''
-        deps = [dep for dep in networkx.descendants(self._tree, node) if dep.build_command]
+        deps = [dep for dep in self._tree.successors(node) if dep.build_command]
         dep_packages = []
         for dep in deps:
             if not dep.packages in dep_packages:
@@ -468,6 +470,20 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             ors += [" || ".join(x.build_command.name() for x in deps if dep_package == x.packages)]
 
         return "\"{}\"".format(" && ".join("( {} )".format(x) for x in ors))
+
+    def remove_external_deps_from_dag(self):
+        '''
+        Bypasses all external dependencies in the DAG and removes them.
+        '''
+        external_nodes = {node for node in self._tree.nodes() if node.build_command is None}
+        for node in external_nodes:
+            predecessors = self._tree.predecessors(node)
+            successors = self._tree.successors(node)
+            for predecessor in predecessors:
+                for successor in successors:
+                    self._tree.add_edge(predecessor, successor)
+            self._tree.remove_node(node)
+
 
 def _create_edges(tree):
     # Use set() to create a copy of the nodes since they change during the loop.

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -468,8 +468,9 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         ors = []
         for dep_package in dep_packages:
             ors += [" || ".join(x.build_command.name() for x in deps if dep_package == x.packages)]
-
-        return "\"{}\"".format(" && ".join("( {} )".format(x) for x in ors))
+        if ors:
+            return "\"{}\"".format(" && ".join("( {} )".format(x) for x in ors))
+        return ""
 
     def remove_external_deps_from_dag(self):
         '''

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -458,8 +458,16 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         '''
         Can be used to get the name of all a node's dependencies.
         '''
-        return ", ".join("'{}'".format(dep.build_command.name()) for dep in networkx.descendants(self._tree, node)
-                                                                    if dep.build_command)
+        deps = [dep for dep in networkx.descendants(self._tree, node) if dep.build_command]
+        dep_packages = []
+        for dep in deps:
+            if not dep.packages in dep_packages:
+                dep_packages += [dep.packages]
+        ors = []
+        for dep_package in dep_packages:
+            ors += [" || ".join(x.build_command.name() for x in deps if dep_package == x.packages)]
+
+        return "\"{}\"".format(" && ".join("( {} )".format(x) for x in ors))
 
 def _create_edges(tree):
     # Use set() to create a copy of the nodes since they change during the loop.

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -467,7 +467,10 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                 dep_packages += [dep.packages]
         ors = []
         for dep_package in dep_packages:
-            ors += [" || ".join(x.build_command.name() for x in deps if dep_package == x.packages)]
+            # This is choosing only one package for each set of equivalent dependencies to use as a dependency:
+            ors += [next(x.build_command.name() for x in deps if dep_package == x.packages)]
+            # To logically or all equivalent dependencies for this package use the following instead:
+            # ors += [" || ".join(x.build_command.name() for x in deps if dep_package == x.packages)]
         if ors:
             return "\"{}\"".format(" && ".join("( {} )".format(x) for x in ors))
         return ""

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -465,14 +465,14 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         for dep in deps:
             if not dep.packages in dep_packages:
                 dep_packages += [dep.packages]
-        ors = []
+        terms = []
         for dep_package in dep_packages:
             # This is choosing only one package for each set of equivalent dependencies to use as a dependency:
-            ors += [next(x.build_command.name() for x in deps if dep_package == x.packages)]
+            terms += [next(x.build_command.name() for x in deps if dep_package == x.packages)]
             # To logically or all equivalent dependencies for this package use the following instead:
-            # ors += [" || ".join(x.build_command.name() for x in deps if dep_package == x.packages)]
-        if ors:
-            return "\"{}\"".format(" && ".join("( {} )".format(x) for x in ors))
+            # terms += [" || ".join(x.build_command.name() for x in deps if dep_package == x.packages)]
+        if terms:
+            return "\"{}\"".format(" && ".join("( {} )".format(x) for x in terms))
         return ""
 
     def remove_external_deps_from_dag(self):

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -461,19 +461,19 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         Can be used to get the name of all a node's dependencies.
         '''
         deps = [dep for dep in self._tree.successors(node) if dep.build_command]
+
+        # Get unique package groups.
         dep_packages = []
         for dep in deps:
             if not dep.packages in dep_packages:
                 dep_packages += [dep.packages]
+
+        # Get one dependency for each package group.
         terms = []
         for dep_package in dep_packages:
-            # This is choosing only one package for each set of equivalent dependencies to use as a dependency:
             terms += [next(x.build_command.name() for x in deps if dep_package == x.packages)]
-            # To logically or all equivalent dependencies for this package use the following instead:
-            # terms += [" || ".join(x.build_command.name() for x in deps if dep_package == x.packages)]
-        if terms:
-            return "\"{}\"".format(" && ".join("( {} )".format(x) for x in terms))
-        return ""
+
+        return ", ".join("'{}'".format(x) for x in terms)
 
     def remove_external_deps_from_dag(self):
         '''

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -600,8 +600,8 @@ def test_get_build_copmmand_dependencies():
     mock_build_tree._tree = sample_build_commands()
     results = [mock_build_tree.build_command_dependencies(node) for node in mock_build_tree.BuildNodes()]
     assert "" in results
-    assert "'recipe2-py2-6-cpu-openmpi-10-2'" in results
-    assert "'recipe2-py2-6-cpu-openmpi-10-2', 'recipe3'" in results or "'recipe3', 'recipe2-py2-6-cpu-openmpi-10-2'" in results
+    assert "\"( recipe2-py2-6-cpu-openmpi-10-2 )\"" in results
+    assert "\"( recipe2-py2-6-cpu-openmpi-10-2 ) && ( recipe3 )\"" in results or "\"( recipe3 ) && ( recipe2-py2-6-cpu-openmpi-10-2 )\"" in results
 
 def test_search_no_timestamp(mocker):
     from open_ce import conda_utils

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -600,8 +600,8 @@ def test_get_build_copmmand_dependencies():
     mock_build_tree._tree = sample_build_commands()
     results = [mock_build_tree.build_command_dependencies(node) for node in mock_build_tree.BuildNodes()]
     assert "" in results
-    assert "\"( recipe2-py2-6-cpu-openmpi-10-2 )\"" in results
-    assert "\"( recipe2-py2-6-cpu-openmpi-10-2 ) && ( recipe3 )\"" in results or "\"( recipe3 ) && ( recipe2-py2-6-cpu-openmpi-10-2 )\"" in results
+    assert "'recipe2-py2-6-cpu-openmpi-10-2'" in results
+    assert "'recipe2-py2-6-cpu-openmpi-10-2', 'recipe3'" in results or "'recipe3', 'recipe2-py2-6-cpu-openmpi-10-2'" in results
 
 def test_search_no_timestamp(mocker):
     from open_ce import conda_utils

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -615,3 +615,24 @@ def test_search_no_timestamp(mocker):
     package_info = conda_utils.get_latest_package_info([], package)
 
     print("Package Info: ", package_info)
+
+def test_dag_cleanup():
+    '''
+    Test that external packages are removed during cleanup.
+    '''
+    mock_build_tree = TestBuildTree([], "3.6", "cpu", "openmpi", "10.2")
+    mock_build_tree._tree = sample_build_commands()
+
+    external_node = build_tree.DependencyNode(packages=["external_package"])
+    nodes = mock_build_tree._tree.nodes()
+    parent_node = list(mock_build_tree._tree.nodes())[0]
+    child_node = list(mock_build_tree._tree.nodes())[1]
+    mock_build_tree._tree.add_node(external_node)
+    mock_build_tree._tree.add_edge(parent_node, external_node)
+    mock_build_tree._tree.add_edge(external_node, child_node)
+
+    mock_build_tree.remove_external_deps_from_dag()
+
+    assert not external_node in mock_build_tree._tree.nodes()
+    assert child_node in mock_build_tree._tree.successors(parent_node)
+    assert parent_node in mock_build_tree._tree.predecessors(child_node)

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -624,9 +624,9 @@ def test_dag_cleanup():
     mock_build_tree._tree = sample_build_commands()
 
     external_node = build_tree.DependencyNode(packages=["external_package"])
-    nodes = mock_build_tree._tree.nodes()
-    parent_node = list(mock_build_tree._tree.nodes())[0]
-    child_node = list(mock_build_tree._tree.nodes())[1]
+    nodes = list(mock_build_tree._tree.nodes())
+    parent_node = nodes[0]
+    child_node = nodes[1]
     mock_build_tree._tree.add_node(external_node)
     mock_build_tree._tree.add_edge(parent_node, external_node)
     mock_build_tree._tree.add_edge(external_node, child_node)


### PR DESCRIPTION
From @bnemanich 

>  It looks like argo DOES support booleans within the depends field: https://argoproj.github.io/argo-workflows/enhanced-depends-logic/. So at some point we could have the graph say that it only requires some variant of tensorflow-base to build tensorflow-estimator

**Update:**

The boolean `||` still requires all of the `OR`d jobs to finish before moving on. So instead of using the boolean logic for dependencies, we're only depending on a single equivalent package.