### PR TITLE
Use recipe channels for remote deps.

### DIFF
--- a/.github/workflows/builder-unit-test.yml
+++ b/.github/workflows/builder-unit-test.yml
@@ -67,7 +67,7 @@ jobs:
           pip install -e .
           pytest tests/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.5.0
+        uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
           directory: ./

--- a/.github/workflows/builder-unit-test.yml
+++ b/.github/workflows/builder-unit-test.yml
@@ -67,7 +67,7 @@ jobs:
           pip install -e .
           pytest tests/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.5.0
         with:
           file: ./coverage.xml
           directory: ./

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Open-CE Specific Ignores
 condabuild/
 
+# VSCode Files
+.vscode/
+*.code-workspace
+
 # Byte-compiled / optimized / DLL files
 *__pycache__/
 *.py[cod]

--- a/open_ce/build_command.py
+++ b/open_ce/build_command.py
@@ -49,9 +49,7 @@ class BuildCommand():
         self.version = version
         self.recipe_path = recipe_path
         self.runtime_package = runtime_package
-        self.output_files = set()
-        if output_files:
-            self.output_files = set(output_files)
+        self.output_files = set(output_files) if output_files else set()
         self.python = python
         self.build_type = build_type
         self.mpi_type = mpi_type
@@ -60,7 +58,7 @@ class BuildCommand():
         self.host_dependencies = host_dependencies
         self.build_dependencies = build_dependencies
         self.test_dependencies = test_dependencies
-        self.channels = channels
+        self.channels = channels if channels else []
         self.conda_build_configs = conda_build_configs
 
     def feedstock_args(self):

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -346,7 +346,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                     if package_name in seen:
                         continue
                     seen.add(package_name)
-                    package_info = conda_utils.get_latest_package_info(self._channels + ancestor_channels + node.channels,
+                    # Pass in channels ordered by priority.
+                    package_info = conda_utils.get_latest_package_info(node.channels + ancestor_channels + self._channels,
                                                                        package)
                     dep_graph.add_node(DependencyNode({package}))
                     for dep in package_info['dependencies']:

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -336,7 +336,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         try:
             while deps:
                 node = deps.pop()
-                ancestor_build_cmds = {x.build_command for x in networkx.ancestors(dep_graph, node) if x.build_command is not None}
+                ancestor_build_cmds = {x.build_command for x in networkx.ancestors(dep_graph, node)
+                                                                if x.build_command is not None}
                 ancestor_channels = []
                 for cmd in ancestor_build_cmds:
                     ancestor_channels += cmd.channels
@@ -345,7 +346,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                     if package_name in seen:
                         continue
                     seen.add(package_name)
-                    package_info = conda_utils.get_latest_package_info(self._channels + node.channels + ancestor_channels, package)
+                    package_info = conda_utils.get_latest_package_info(self._channels + node.channels + ancestor_channels,
+                                                                       package)
                     dep_graph.add_node(DependencyNode({package}))
                     for dep in package_info['dependencies']:
                         dep_name = utils.remove_version(dep)

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -44,9 +44,7 @@ class DependencyNode():
                  channels=None):
         self.packages = packages
         self.build_command = build_command
-        self.channels = channels
-        if not self.channels:
-            self.channels = []
+        self.channels = channels if channels else []
         self._hash_val = hash(self.build_command)
 
     def __repr__(self):

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -336,12 +336,16 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         try:
             while deps:
                 node = deps.pop()
+                ancestor_build_cmds = {x.build_command for x in networkx.ancestors(dep_graph, node) if x.build_command is not None}
+                ancestor_channels = []
+                for cmd in ancestor_build_cmds:
+                    ancestor_channels += cmd.channels
                 for package in node.packages:
                     package_name = utils.remove_version(package)
                     if package_name in seen:
                         continue
                     seen.add(package_name)
-                    package_info = conda_utils.get_latest_package_info(self._channels + node.channels, package)
+                    package_info = conda_utils.get_latest_package_info(self._channels + node.channels + ancestor_channels, package)
                     dep_graph.add_node(DependencyNode({package}))
                     for dep in package_info['dependencies']:
                         dep_name = utils.remove_version(dep)

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -346,7 +346,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                     if package_name in seen:
                         continue
                     seen.add(package_name)
-                    package_info = conda_utils.get_latest_package_info(self._channels + node.channels + ancestor_channels,
+                    package_info = conda_utils.get_latest_package_info(self._channels + ancestor_channels + node.channels,
                                                                        package)
                     dep_graph.add_node(DependencyNode({package}))
                     for dep in package_info['dependencies']:

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -87,12 +87,11 @@ def conda_package_info(channels, package):
     Get conda package info.
     '''
     # Call "conda search --info" through conda's cli.python_api
-    channel_args = sum((["-c", channel] for channel in channels), [])
+    all_channel_args = sum(([["-c", channel]] for channel in channels), [[]])
     entries = list()
     fail_count = 0
     all_std_out = ""
-    for index, channel in enumerate(channels):
-        channel_args = ["-c", channel]
+    for index, channel_args in enumerate(all_channel_args):
         search_args = ["--info", generalize_version(package)] + channel_args
         # Setting the logging level allows us to ignore unnecessary output
         getLogger("conda.common.io").setLevel(ERROR)
@@ -118,7 +117,7 @@ def conda_package_info(channels, package):
                 entries.append(entry)
         if ret_code:
             fail_count += 1
-    if fail_count > 0 and fail_count >= len(channels):
+    if not entries or (fail_count > 0 and fail_count >= len(channels)):
         raise OpenCEError(Error.CONDA_PACKAGE_INFO, generalize_version(package), all_std_out)
     return entries
 

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -137,6 +137,7 @@ def get_latest_package_info(channels, package):
                 if package_info["timestamp"] < retval["timestamp"]:
                     continue
                 retval = package_info
+            print(retval)
             return retval
     raise OpenCEError(Error.CONDA_PACKAGE_INFO, "conda search --info " + generalize_version(package), all_std_out)
 

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -140,23 +140,6 @@ def get_latest_package_info(channels, package):
             return retval
     raise OpenCEError(Error.CONDA_PACKAGE_INFO, "conda search --info " + generalize_version(package), all_std_out)
 
-# def (channels, package):
-#     '''
-#     Get the conda package info for the most recent search result.
-#     '''
-#     package_infos = conda_package_info(channels, package)
-#     retval = package_infos[0]
-#     for package_info in package_infos:
-#         if package_info["version_order"] > retval["version_order"]:
-#             retval = package_info
-#         elif package_info["version_order"] == retval["version_order"]:
-#             if package_info["channel_order"] > retval["channel_order"]:
-#                 retval = package_info
-#             elif package_info["channel_order"] == retval["channel_order"]:
-#                 if package_info["timestamp"] > retval["timestamp"]:
-#                     retval = package_info
-#     return retval
-
 def version_matches_spec(spec_string, version=open_ce_version):
     '''
     Uses conda version specification syntax to check if version matches spec_string.

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -137,7 +137,6 @@ def get_latest_package_info(channels, package):
                 if package_info["timestamp"] < retval["timestamp"]:
                     continue
                 retval = package_info
-            print(retval)
             return retval
     raise OpenCEError(Error.CONDA_PACKAGE_INFO, "conda search --info " + generalize_version(package), all_std_out)
 

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -722,7 +722,7 @@ def test_search_package_priority(mocker):
     dep_graph.add_edge(parent_node, external_node)
 
 
-    def mocked_search(command, *arguments, **kwargs):
+    def mocked_search(*arguments, **_):
         search_results = {("external_package", "conda_forge"): make_search_result(package_name="external_package",
                                                                                   package_version="2.0",
                                                                                   deps=["conda_forge_dep"]),
@@ -732,9 +732,8 @@ def test_search_package_priority(mocker):
                           ("defaults_dep", "conda_forge"): make_search_result(package_name="defaults_dep",
                                                                               deps=["defaults_dep_conda_forge_dep"]),
                           ("defaults_dep", "defaults"): empty_search_result("defaults_dep")}
-        print(arguments[0])
-        package = arguments[0][1]
-        channel = arguments[0][4] if "-c" in arguments[0] else ""
+        package = arguments[1][1]
+        channel = arguments[1][4] if "-c" in arguments[1] else ""
         if (package, channel) in search_results:
             return search_results[(package, channel)]
         else:

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -89,12 +89,14 @@ class TestBuildTree(build_tree.BuildTree):
                  mpi_types,
                  cuda_versions,
                  repository_folder="./",
+                 channels=None,
                  git_location=utils.DEFAULT_GIT_LOCATION,
                  git_tag_for_env=utils.DEFAULT_GIT_TAG,
                  git_up_to_date = False,
                  conda_build_config=utils.DEFAULT_CONDA_BUILD_CONFIG):
         self._env_config_files = env_config_files
         self._repository_folder = repository_folder
+        self._channels = channels if channels else []
         self._git_location = git_location
         self._git_tag_for_env = git_tag_for_env
         self._git_up_to_date = git_up_to_date
@@ -636,3 +638,117 @@ def test_dag_cleanup():
     assert not external_node in mock_build_tree._tree.nodes()
     assert child_node in mock_build_tree._tree.successors(parent_node)
     assert parent_node in mock_build_tree._tree.predecessors(child_node)
+
+def test_search_channels(mocker):
+    '''
+    Test that recipe specific channels are used for remote dependency discovery.
+    '''
+    mock_build_tree = TestBuildTree([], "3.6", "cpu", "openmpi", "10.2", channels=["defaults"])
+    dep_graph = sample_build_commands()
+
+    external_node = build_tree.DependencyNode(packages=["external_package"])
+    nodes = list(dep_graph.nodes())
+    parent_node = nodes[0]
+    parent_node.build_command.channels = ["conda_forge"]
+    dep_graph.add_node(external_node)
+    dep_graph.add_edge(parent_node, external_node)
+
+    def validate_channels(channels, package):
+        assert "defaults" in channels
+        if package == "external_package":
+            assert "conda_forge" in channels, \
+                   "The conda_forge channel should come from the parent node."
+
+            assert channels.index("conda_forge") < channels.index("defaults"), \
+                   "The conda_forge channel should be higher priority, since it is from a parent node and the defaults channel is from the env file."
+        return {'dependencies': []}
+
+    mocker.patch(
+        'open_ce.conda_utils.get_latest_package_info',
+        side_effect=validate_channels
+    )
+
+    mock_build_tree._create_remote_deps(dep_graph)
+
+def make_search_result(package_name="some_package",
+                       package_version="1.0",
+                       build_number="1",
+                       deps=None):
+    if not deps:
+        deps = []
+
+    return '''
+Loading channels: done
+{0} {1} {2}
+-----------------
+file name   : {0}-{1}.conda
+name        : {0}
+version     : {1}
+build       : 0
+build number: {2}
+size        : 20 KB
+license     : BSD
+subdir      : linux-ppc64le
+url         : https://repo.anaconda.com/pkgs/main/linux-ppc64le/
+md5         : 4691146ff587f371f83f0e7bab93b63b
+dependencies: 
+{3}
+
+
+
+'''.format(package_name, package_version, build_number, "\n".join("    - {}".format(dep) for dep in deps)), 0, 0
+
+def empty_search_result(package_name):
+    return '''
+Loading channels: done
+No match found for: {0}. Search: *{0}*
+
+
+'''.format(package_name), 0, 1
+
+def test_search_package_priority(mocker):
+    '''
+    Test remote package priority.
+    '''
+    mock_build_tree = TestBuildTree([], "3.6", "cpu", "openmpi", "10.2", channels=["defaults"])
+    dep_graph = sample_build_commands()
+
+    external_node = build_tree.DependencyNode(packages=["external_package"])
+    nodes = list(dep_graph.nodes())
+    parent_node = nodes[0]
+    #defaults is the highest priority conda channel, a package should only come from conda_forge if there are none in defaults, regardless of version.
+    parent_node.build_command.channels = ["defaults", "conda_forge"]
+    dep_graph.add_node(external_node)
+    dep_graph.add_edge(parent_node, external_node)
+
+
+    def mocked_search(command, *arguments, **kwargs):
+        search_results = {("external_package", "conda_forge"): make_search_result(package_name="external_package",
+                                                                                  package_version="2.0",
+                                                                                  deps=["conda_forge_dep"]),
+                          ("external_package", "defaults"): make_search_result(package_name="external_package",
+                                                                               package_version="1.0",
+                                                                               deps=["defaults_dep"]),
+                          ("defaults_dep", "conda_forge"): make_search_result(package_name="defaults_dep",
+                                                                              deps=["defaults_dep_conda_forge_dep"]),
+                          ("defaults_dep", "defaults"): empty_search_result("defaults_dep")}
+        print(arguments[0])
+        package = arguments[0][1]
+        channel = arguments[0][4] if "-c" in arguments[0] else ""
+        if (package, channel) in search_results:
+            return search_results[(package, channel)]
+        else:
+            return make_search_result(package_name=package)
+
+    mocker.patch(
+        'conda.cli.python_api.run_command',
+        side_effect=mocked_search
+    )
+
+    dep_graph = mock_build_tree._create_remote_deps(dep_graph)
+
+    assert build_tree.DependencyNode(packages={"defaults_dep"}) in list(dep_graph.successors(external_node)), \
+           "defaults_dep should be found, even though the conda_forge package is a newer version"
+
+    assert build_tree.DependencyNode(packages={"defaults_dep_conda_forge_dep"}) in list(dep_graph.successors(build_tree.DependencyNode(packages={"defaults_dep"}))), \
+           "There is no defaults_dep package in the defaults channel, so conda_forge should be used."


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

@npanpaliya added an external channel to the xgboost env file and it wasn't being used during remote dependency retrieval. 

> use xgboost branch from  https://github.com/npanpaliya/xgboost-feedstock/tree/142-update and run validate config, it would fail.
> ```
> $> open-ce validate config --conda_build_config=./open-ce/envs/conda_build_config.yaml xgboost-env.yaml 
> ...
> PackagesNotFoundError: The following packages are not available from current channels:
>   - gcc_linux-64=8.4.0
> ```
