### PR TITLE
Fix the build string for torchvision-cpu

### DIFF
--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -70,6 +70,12 @@ def get_output_file_paths(meta, variants):
     config = get_or_merge_config(None, variant=variants)
     config.verbose = False
 
+    # Fix case where output build string hasn't been properly added to the package build string
+    # This has been seen in the torchvision-cpu package.
+    output = meta.get_rendered_output(meta.name(), permit_undefined_jinja=True)
+    if output:
+        conda_build.metadata.combine_top_level_metadata_with_output(meta, output)
+
     out_files = conda_build.api.get_output_file_paths(meta, config=config)
 
     # Only return the package name and the parent directory. This will show where within the output

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -173,7 +173,7 @@ def generalize_version(package):
     package = re.sub(r'\s+', ' ', package)
 
     # Check if we want to add .* to the end of versions
-    py_matched = re.match(r'([\w-]+)([\s=<>]*)(\d[.\d*\w*]*)([=\s]*.*)', package)
+    py_matched = re.match(r'([\w-]+)([\s=<>]*)(\d[.\d*\w*!]*)([=\s]*.*)', package)
 
     if py_matched:
         name = py_matched.group(1)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -118,15 +118,17 @@ def make_render_result(package_name, build_reqs=None, run_reqs=None, host_reqs=N
     if not host_reqs: host_reqs = []
     if not test_reqs: test_reqs = []
     if not string: string = ''
+    meta = {'package': {'name': package_name, 'version': '1.2.3'},
+            'source': {'git_url': 'https://github.com/'+package_name+'.git', 'git_rev': 'v0.19.5', 'patches': []},
+            'build': {'number': '1', 'string': 'py37_1'},
+            'requirements': {'build': build_reqs, 'host': host_reqs, 'run': run_reqs + ["upstreamdep1   2.3","upstreamdep2   2"], 'run_constrained': []},
+            'test': {'requires': test_reqs},
+            'about': {'home': 'https://github.com/'+package_name+'.git', 'license_file': 'LICENSE', 'summary': package_name},
+            'extra': {'final': True}}
 
-    retval = [(Namespace(meta={
-                            'package': {'name': package_name, 'version': '1.2.3'},
-                            'source': {'git_url': 'https://github.com/'+package_name+'.git', 'git_rev': 'v0.19.5', 'patches': []},
-                            'build': {'number': '1', 'string': 'py37_1'},
-                            'requirements': {'build': build_reqs, 'host': host_reqs, 'run': run_reqs + ["upstreamdep1   2.3","upstreamdep2   2"], 'run_constrained': []},
-                            'test': {'requires': test_reqs},
-                            'about': {'home': 'https://github.com/'+package_name+'.git', 'license_file': 'LICENSE', 'summary': package_name},
-                            'extra': {'final': True}}),
+    retval = [(Namespace(meta=meta,
+                         name=lambda : package_name,
+                         get_rendered_output=lambda name,permit_undefined_jinja : meta),
                       True,
                       None)]
     return retval


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

The generated conda environment files have the wrong build string for torchvision-cpu. This appears to be due to how things are rendered when there is only a single output and the output name doesn't match the overal "package" name. This can be resolved by using a couple of the internal conda_build functions.

The version regex was modified as well because some packages have a `!` in their version string.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
