### PR TITLE
Fix CI build due to cudatoolkit not being defined

### DIFF
--- a/tests/feedstock_tests/check_build_numbers.py
+++ b/tests/feedstock_tests/check_build_numbers.py
@@ -42,10 +42,15 @@ def main(arg_strings=None):
     for variant in variants:
         utils.run_and_log("git checkout {}".format(default_branch))
         main_build_config_data, main_config = get_configs(variant, args.conda_build_configs)
+        if main_build_config_data["recipes"] is None:
+            continue
         main_build_numbers = get_build_numbers(main_build_config_data, main_config, variant)
 
         utils.run_and_log("git checkout {}".format(pr_branch))
         pr_build_config_data, pr_config = get_configs(variant, args.conda_build_configs)
+        if pr_build_config_data["recipes"] is None:
+            continue
+
         current_pr_build_numbers = get_build_numbers(pr_build_config_data, pr_config, variant)
 
         print("Build Info for Variant:   {}".format(variant))

--- a/tests/feedstock_tests/check_recipes.py
+++ b/tests/feedstock_tests/check_recipes.py
@@ -36,6 +36,8 @@ def main(arg_strings=None):
     check_result = True
     for variant in variants:
         main_build_config_data, main_config = get_configs(variant, args.conda_build_configs)
+        if main_build_config_data["recipes"] is None:
+            continue
         if not check_recipes(main_build_config_data, main_config, variant):
             check_result = False
             print("Recipe validation failed for variant '{}'.".format(variant))

--- a/tests/test-conda-env3.yaml
+++ b/tests/test-conda-env3.yaml
@@ -5,4 +5,6 @@ dependencies:
 - pytest 6.2.2
 - libopus 1.3.1
 - icu 58.2
+- libgcc-ng=8.2
+- libstdcxx-ng=8.2
 name: opence-conda-env-py3.6-cuda-openmpi


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

To fix workflow builds of cuda only packages like TRT, nccl, magma, cudnn, etc. which errors out as below -
```
--->git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
239
Error: Failed to render jinja template in /home/runner/work/magma-feedstock/magma-feedstock/recipe/meta.yaml:
240
--->git checkout main
241
'cudatoolkit' is undefined
```
we need to add {% if build_type == "cuda" %} in the config/build-config.yaml files of the feedstocks. And then for this condition to work, we need the changes done in the PR. 



## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
