### PR TITLE
Fix Ci Slowdown

### DIFF
--- a/open_ce/errors.py
+++ b/open_ce/errors.py
@@ -29,7 +29,7 @@ class Error(Enum):
     BUILD_IN_CONTAINER = (4, "Error executing build in container: \"{}\"")
     BUILD_IMAGE = (5, "Failure building image: \"{}\"")
     VALIDATE_ENV = (6, "Error validating \"{}\" for variant {}\n{}")
-    VALIDATE_CONFIG = (7, "Error validating \"{}\" for \"{}\" in variant \"{}\"\n{}")
+    VALIDATE_CONFIG = (7, "Error validating \"{}\" for \"{}\":\n{}")
     CONFIG_CONTENT = (8, "Content Error!:\n"
                          "An environment file needs to specify packages or "
                          "import another environment file.")

--- a/open_ce/validate_config.py
+++ b/open_ce/validate_config.py
@@ -38,15 +38,16 @@ def validate_config(args):
     from open_ce.build_tree import construct_build_tree  # pylint: disable=import-outside-toplevel
 
     variants = utils.make_variants(args.python_versions, args.build_types, args.mpi_types, args.cuda_versions)
-
+    env_files = list(args.env_config_file) #make a copy of the env_file list
     for variant in variants:
-        for env_file in args.env_config_file:
+        for env_file in env_files:
             print('Validating {} for {} : {}'.format(args.conda_build_configs, env_file, variant))
             try:
                 args.python_versions = variant.get('python')
                 args.build_types = variant.get('build_type')
                 args.mpi_types = variant.get('mpi_type')
                 args.cuda_versions = variant.get('cudatoolkit')
+                args.env_config_file = [env_file]
                 _ = construct_build_tree(args)
             except OpenCEError as err:
                 raise OpenCEError(Error.VALIDATE_CONFIG, args.conda_build_configs, env_file, variant, err.msg) from err

--- a/open_ce/validate_config.py
+++ b/open_ce/validate_config.py
@@ -37,21 +37,14 @@ def validate_config(args):
     # existence of conda-build as BuildTree uses conda_build APIs.
     from open_ce.build_tree import construct_build_tree  # pylint: disable=import-outside-toplevel
 
-    variants = utils.make_variants(args.python_versions, args.build_types, args.mpi_types, args.cuda_versions)
-    env_files = list(args.env_config_file) #make a copy of the env_file list
-    for variant in variants:
-        for env_file in env_files:
-            print('Validating {} for {} : {}'.format(args.conda_build_configs, env_file, variant))
-            try:
-                args.python_versions = variant.get('python')
-                args.build_types = variant.get('build_type')
-                args.mpi_types = variant.get('mpi_type')
-                args.cuda_versions = variant.get('cudatoolkit')
-                args.env_config_file = [env_file]
-                _ = construct_build_tree(args)
-            except OpenCEError as err:
-                raise OpenCEError(Error.VALIDATE_CONFIG, args.conda_build_configs, env_file, variant, err.msg) from err
-            print('Successfully validated {} for {} : {}'.format(args.conda_build_configs, env_file, variant))
+    for env_file in list(args.env_config_file): #make a copy of the env_file list
+        print('Validating {} for {}'.format(args.conda_build_configs, env_file))
+        try:
+            args.env_config_file = [env_file]
+            _ = construct_build_tree(args)
+        except OpenCEError as err:
+            raise OpenCEError(Error.VALIDATE_CONFIG, args.conda_build_configs, env_file, err.msg) from err
+        print('Successfully validated {} for {}'.format(args.conda_build_configs, env_file))
 
 def validate_build_tree(tree, external_deps, start_nodes=None):
     '''


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?

## Description

CI had slowed down because validation was looping through the env files, but still validating all of them each time.

Also combined all variants to be able to parallelize them. Removes the ability to report a failure for a specific variant, but is a little faster.

Here is a run using these changes:
https://github.com/open-ce/open-ce/pull/436/checks?check_run_id=2823628863