### PR TITLE
Speed up `open-ce get licenses`

### DIFF
--- a/open_ce/get_licenses.py
+++ b/open_ce/get_licenses.py
@@ -17,12 +17,13 @@
 """
 
 import os
-import json
 import datetime
 import glob
 import tarfile
 import zipfile
 import shutil
+import functools
+import operator
 from enum import Enum, unique, auto
 import urllib.parse
 from collections import defaultdict
@@ -87,11 +88,11 @@ class LicenseGenerator():
         The LicenseInfo class holds license information for a single package.
         """
         #pylint: disable=too-many-arguments
-        def __init__(self, name, version, url, license_type, copyrights, license_files):
+        def __init__(self, name, version, url=None, license_type=None, copyrights=None, license_files=None):
             self.name = name
             self.version = version
             self.url = url if isinstance(url, list) else [url]
-            self.license_type = _clean_license_type(license_type)
+            self.license_type = _clean_license_type(license_type) if license_type else license_type
             self.license_files = license_files
             self.copyrights = copyrights
 
@@ -136,61 +137,60 @@ class LicenseGenerator():
         if not ret_code:
             raise OpenCEError(Error.GET_LICENSES, cli, std_out, std_err)
 
-    def add_licenses_from_info_file(self, license_file):
+    def add_licenses_from_info_files(self, license_data):
         """
-        Add all of the licensing information from an info file.
+        Add all of the license information from a list of open-ce-info licence info.
         """
-        if not os.path.exists(license_file):
-            return
+        # Get all of the license information from package's open-ce-info files.
+        info_file_licenses = utils.run_in_parallel(self._get_licenses_from_info_file_helper, license_data)
+        self._licenses.update(filter(None, info_file_licenses))
 
-        with open(license_file) as file_stream:
-            license_data = open_ce.yaml_utils.load(file_stream)
+    def _get_licenses_from_info_file_helper(self, package):
+        if LicenseGenerator.LicenseInfo(package[Key.name.name], package[Key.version.name]) in self._licenses:
+            return None
 
-        utils.validate_dict_schema(license_data, _OPEN_CE_INFO_SCHEMA)
+        source_folder = os.path.join(utils.TMP_LICENSE_DIR,
+                                     package[Key.name.name] + "-" + str(package[Key.version.name]))
+        if not os.path.exists(source_folder):
+            os.makedirs(source_folder)
 
-        for package in license_data.get(Key.third_party_packages.name, []):
-            source_folder = os.path.join(utils.TMP_LICENSE_DIR,
-                                         package[Key.name.name] + "-" + str(package[Key.version.name]))
-            if not os.path.exists(source_folder):
-                os.makedirs(source_folder)
+            urls = [package[Key.license_url.name]] if Key.license_url.name in package else package[Key.url.name]
 
-                urls = [package[Key.license_url.name]] if Key.license_url.name in package else package[Key.url.name]
+            # Download the source from each URL
+            for url in urls:
+                if url.endswith(".git"):
+                    try:
+                        utils.git_clone(url, package[Key.version.name], source_folder)
+                    except OpenCEError:
+                        print("Unable to clone source for " + package[Key.name.name])
+                else:
+                    try:
+                        res = requests.get(url)
+                        local_path = os.path.join(source_folder, os.path.basename(url))
+                        with open(local_path, 'wb') as file_stream:
+                            file_stream.write(res.content)
+                        _extract(local_path, source_folder)
 
-                # Download the source from each URL
-                for url in urls:
-                    if url.endswith(".git"):
-                        try:
-                            utils.git_clone(url, package[Key.version.name], source_folder)
-                        except OpenCEError:
-                            print("Unable to clone source for " + package[Key.name.name])
-                    else:
-                        try:
-                            res = requests.get(url)
-                            local_path = os.path.join(source_folder, os.path.basename(url))
-                            with open(local_path, 'wb') as file_stream:
-                                file_stream.write(res.content)
-                            _extract(local_path, source_folder)
+                    #pylint: disable=broad-except
+                    except Exception:
+                        print("Unable to download source for " + package[Key.name.name])
 
-                        #pylint: disable=broad-except
-                        except Exception:
-                            print("Unable to download source for " + package[Key.name.name])
+        # Find every license file within the downloaded source
+        license_files = _find_license_files(source_folder, package.get(Key.license_files.name))
 
-            # Find every license file within the downloaded source
-            license_files = _find_license_files(source_folder, package.get(Key.license_files.name))
+        # Get copyright information from the downloaded source (unless the copyright string is provided)
+        if Key.copyright_string.name in package:
+            copyright_string = [package[Key.copyright_string.name]]
+        else:
+            copyright_string = _get_copyrights_from_files(license_files)
 
-            # Get copyright information from the downloaded source (unless the copyright string is provided)
-            if Key.copyright_string.name in package:
-                copyright_string = [package[Key.copyright_string.name]]
-            else:
-                copyright_string = _get_copyrights_from_files(license_files)
-
-            info = LicenseGenerator.LicenseInfo(package[Key.name.name],
-                                                package[Key.version.name],
-                                                package[Key.url.name],
-                                                package[Key.license.name],
-                                                copyright_string,
-                                                license_files)
-            self._licenses.add(info)
+        info = LicenseGenerator.LicenseInfo(package[Key.name.name],
+                                            package[Key.version.name],
+                                            package[Key.url.name],
+                                            package[Key.license.name],
+                                            copyright_string,
+                                            license_files)
+        return info
 
     def write_licenses_file(self, output_folder):
         """
@@ -234,33 +234,53 @@ class LicenseGenerator():
 
     def _add_licenses_from_environment(self, conda_env):
         # For each meta-pkg within an environment, find its about.json file.
-        meta_files = [meta_file for meta_file in os.listdir(os.path.join(conda_env, "conda-meta"))
+        meta_file_args = [(meta_file, conda_env) for meta_file in os.listdir(os.path.join(conda_env, "conda-meta"))
                           if meta_file.endswith('.json')]
 
-        for meta_file in meta_files:
-            # Find the extracted_package_dir
-            with open(os.path.join(conda_env, "conda-meta", meta_file)) as file_stream:
-                meta_data = json.load(file_stream)
+        licenses = utils.run_in_parallel(self._add_licenses_from_environment_helper, meta_file_args)
+        local_licenses, info_file_packages = zip(*licenses)
 
-            package_info_dir = os.path.join(meta_data["extracted_package_dir"], "info")
-            with open(os.path.join(package_info_dir, "about.json")) as file_stream:
-                about_data = json.load(file_stream)
+        self._licenses.update(filter(None, local_licenses))
+        self.add_licenses_from_info_files(functools.reduce(operator.iconcat, info_file_packages, []))
 
-            open_ce_info = os.path.join(package_info_dir, "recipe", utils.OPEN_CE_INFO_FILE)
-            self.add_licenses_from_info_file(open_ce_info)
+    def _add_licenses_from_environment_helper(self, meta_file, conda_env):
+        # Find the extracted_package_dir
+        with open(os.path.join(conda_env, "conda-meta", meta_file)) as file_stream:
+            meta_data = open_ce.yaml_utils.load(file_stream)
 
-            copyright_strings, license_files = _get_copyrights_from_conda_package(meta_data["extracted_package_dir"])
+        if LicenseGenerator.LicenseInfo(meta_data["name"], meta_data["version"]) in self._licenses:
+            return (None, [])
 
-            info = LicenseGenerator.LicenseInfo(meta_data["name"],
-                                                meta_data["version"],
-                                                about_data.get("dev_url", about_data.get("home", "none")),
-                                                about_data.get("license", "none"),
-                                                copyright_strings,
-                                                license_files)
-            self._licenses.add(info)
+        package_info_dir = os.path.join(meta_data["extracted_package_dir"], "info")
+        with open(os.path.join(package_info_dir, "about.json")) as file_stream:
+            about_data = open_ce.yaml_utils.load(file_stream)
 
-        if os.path.exists(utils.TMP_LICENSE_DIR):
-            shutil.rmtree(utils.TMP_LICENSE_DIR)
+        info_file_packages = _get_info_file_packages(package_info_dir)
+
+        copyright_strings, license_files = _get_copyrights_from_conda_package(meta_data["extracted_package_dir"])
+
+        info = LicenseGenerator.LicenseInfo(meta_data["name"],
+                                            meta_data["version"],
+                                            about_data.get("dev_url", about_data.get("home", "none")),
+                                            about_data.get("license", "none"),
+                                            copyright_strings,
+                                            license_files)
+        return info, info_file_packages
+
+def _get_info_file_packages(package_info_dir):
+    """
+    Get a list of all of the license information from a package's open-ce-info file.
+    """
+    open_ce_info = os.path.join(package_info_dir, "recipe", utils.OPEN_CE_INFO_FILE)
+    if not os.path.exists(open_ce_info):
+        return []
+
+    with open(open_ce_info) as file_stream:
+        license_data = open_ce.yaml_utils.load(file_stream)
+
+    utils.validate_dict_schema(license_data, _OPEN_CE_INFO_SCHEMA)
+
+    return license_data.get(Key.third_party_packages.name, [])
 
 def _get_copyrights_from_conda_package(pkg_dir):
     """
@@ -505,5 +525,8 @@ def get_licenses(args):
     if args.template_files:
         for template_file in parse_arg_list(args.template_files):
             gen.gen_file_from_template(template_file, args.output_folder)
+
+    if os.path.exists(utils.TMP_LICENSE_DIR):
+        shutil.rmtree(utils.TMP_LICENSE_DIR)
 
 ENTRY_FUNCTION = get_licenses

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -372,7 +372,7 @@ def run_in_parallel(function, arguments):
     '''
     Run function in parallel across all arguments.
     '''
-    new_args = [tuple([function]) + (x if isinstance(x, tuple) else tuple(x)) for x in arguments]
+    new_args = [tuple([function]) + x if isinstance(x, tuple) else (function, x) for x in arguments]
     pool = mp.Pool(NUM_THREAD_POOL)
     try:
         retval = pool.starmap(_run_helper, new_args)

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -372,7 +372,7 @@ def run_in_parallel(function, arguments):
     '''
     Run function in parallel across all arguments.
     '''
-    new_args = [tuple([function]) + x for x in arguments]
+    new_args = [tuple([function]) + (x if isinstance(x, tuple) else tuple(x)) for x in arguments]
     pool = mp.Pool(NUM_THREAD_POOL)
     try:
         retval = pool.starmap(_run_helper, new_args)

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -31,7 +31,7 @@ import open_ce.get_licenses as get_licenses
 import open_ce.utils as utils
 from open_ce.errors import OpenCEError
 
-def test_get_licenses(capsys):
+def test_get_licenses(capfd):
     '''
     This is a complete test of `get_licenses`.
     '''
@@ -39,7 +39,7 @@ def test_get_licenses(capsys):
     template_file = "tests/open-ce-licenses.template"
     opence._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env3.yaml", "--output_folder", output_folder, "--template_files", template_file])
 
-    captured = capsys.readouterr()
+    captured = capfd.readouterr()
     assert "Unable to download source for icu-58.2" in captured.out
 
     output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
@@ -95,7 +95,7 @@ def test_get_licenses_no_conda_env():
 
     assert "The \'--conda_env_file\' argument is required." in str(err.value)
 
-def test_add_licenses_from_info_file(capsys):
+def test_add_licenses_from_info_file(capfd):
     '''
     This is a complete test of the add_licenses_from_info_file method.
     '''
@@ -104,7 +104,7 @@ def test_add_licenses_from_info_file(capsys):
     license_info = get_licenses._get_info_file_packages(os.path.join("tests", "test-open-ce-info-1.yaml"))
     gen.add_licenses_from_info_files(license_info)
 
-    captured = capsys.readouterr()
+    captured = capfd.readouterr()
     assert "Unable to clone source for bad_git_package" in captured.out
     assert "Unable to download source for bad_url" in captured.out
 

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -101,7 +101,8 @@ def test_add_licenses_from_info_file(capsys):
     '''
     output_folder = "get_licenses_output"
     gen = get_licenses.LicenseGenerator()
-    gen.add_licenses_from_info_file(os.path.join("tests", "test-open-ce-info-1.yaml"))
+    license_info = get_licenses._get_info_file_packages(os.path.join("tests", "test-open-ce-info-1.yaml"))
+    gen.add_licenses_from_info_files(license_info)
 
     captured = capsys.readouterr()
     assert "Unable to clone source for bad_git_package" in captured.out
@@ -131,7 +132,8 @@ def test_no_info_file():
     '''
     output_folder = "get_licenses_output"
     gen = get_licenses.LicenseGenerator()
-    gen.add_licenses_from_info_file(os.path.join("tests", "no-file.yaml"))
+    license_info = get_licenses._get_info_file_packages(os.path.join("tests", "no-file.yaml"))
+    gen.add_licenses_from_info_files(license_info)
     gen.write_licenses_file(output_folder)
 
     output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

The `open-ce get licenses` command can sometimes take a while to complete. This PR speeds things up by:

1. Fetching information in parallel.
1. Short circuiting when license info for a file has already been found.
1. Uses faster yaml loader.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
