### PR TITLE
Add "Open in VS Code" support to the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Builder Unit Tests](https://github.com/open-ce/open-ce/workflows/Open-CE%20Builder%20Unit%20Tests/badge.svg)](https://github.com/open-ce/open-ce-builder/actions?query=workflow%3A%22Open-CE+Builder+Unit+Tests%22+branch%3Amain)
 [![Builder Unit Test Coverage](https://codecov.io/gh/open-ce/open-ce-builder/branch/main/graph/badge.svg)](https://codecov.io/gh/open-ce/open-ce-builder)
 [![GitHub Licence](https://img.shields.io/github/license/open-ce/open-ce.svg)](LICENSE)
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/open-ce/open-ce-builder)
 ---
 
 # Open-CE Builder


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?

## Description

VS Code just added https://open.vscode.dev and an associated badge so users can open up a repo directly in VS Code without having to check it out first.
[More info here.](https://code.visualstudio.com/updates/v1_58#_open-in-vs-code-badge)
