### PR TITLE
Add channels from Open-CE files to conda env files

### DIFF
--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -82,6 +82,7 @@ def _get_runtime_image_file(container_tool):
         return image_file
 
     tool_ver = tool_ver.replace(".", "")
+    tool_ver = tool_ver.replace("-dev", "")
     if (container_tool == "docker" and int(tool_ver) >= 1709) or \
        (container_tool == "podman" and int(tool_ver) >= 200):
         # Use the newer docker/podman supported Dockerfile

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -198,7 +198,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         validate_args = []
         for variant in self._possible_variants:
             try:
-                variant_tree, external_deps = self._create_nodes(variant)
+                variant_tree, external_deps, channels = self._create_nodes(variant)
                 variant_tree = _create_edges(variant_tree)
                 variant_tree = self._create_remote_deps(variant_tree)
                 self._tree = networkx.compose(self._tree, variant_tree)
@@ -225,7 +225,10 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
             validate_args.append((variant_tree, external_deps, variant_start_nodes))
 
-            self._conda_env_files[variant_string] = get_conda_file_packages(variant_tree, external_deps, variant_start_nodes)
+            self._conda_env_files[variant_string] = get_conda_file_packages(variant_tree,
+                                                                            external_deps,
+                                                                            self._channels + channels,
+                                                                            variant_start_nodes)
             self._test_feedstocks[variant_string] = set()
             for build_command in traverse_build_commands(variant_tree, variant_start_nodes):
                 self._test_feedstocks[variant_string].add(build_command.repository)
@@ -268,6 +271,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         env_config_data_list = env_config.load_env_config_files(self._env_config_files, variants)
         feedstocks_seen = set()
         external_deps = []
+        channels_in_env_files = set()
         retval = graph.OpenCEGraph()
         create_commands_args = []
 
@@ -282,7 +286,9 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
         # Create recipe dictionaries for each repository in the environment file
         for env_config_data in env_config_data_list:
-            channels = self._channels + env_config_data.get(env_config.Key.channels.name, [])
+            new_channels = env_config_data.get(env_config.Key.channels.name, [])
+            channels = self._channels + new_channels
+            channels_in_env_files.update(new_channels)
             feedstocks = env_config_data.get(env_config.Key.packages.name, [])
             if not feedstocks:
                 feedstocks = []
@@ -310,7 +316,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         for command in commands:
             retval = networkx.compose(retval, command)
 
-        return retval, external_deps
+        return retval, external_deps, list(channels_in_env_files)
 
     def _create_commands_helper(self, variants, env_config_data, env_conda_build_configs, feedstock):
         channels = self._channels + env_config_data.get(env_config.Key.channels.name, [])
@@ -442,7 +448,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         """
         conda_env_files = dict()
         for variant, conda_env_file in self._conda_env_files.items():
-            conda_env_files[variant] = conda_env_file.write_conda_env_file(variant, self._channels,
+            conda_env_files[variant] = conda_env_file.write_conda_env_file(variant,
                                                                    output_folder, env_file_prefix,
                                                                    path, self._git_tag_for_env)
 
@@ -641,11 +647,11 @@ def get_installable_packages(build_commands, external_deps, starting_nodes=None,
             retval = check_and_add({dep}, retval)
     return sorted(retval, key=len)
 
-def get_conda_file_packages(build_commands, external_deps, starting_nodes=None):
+def get_conda_file_packages(build_commands, external_deps, channels, starting_nodes=None):
     '''
     This function makes the conda env file generator for the installable packages.
     '''
-    return CondaEnvFileGenerator(get_installable_packages(build_commands, external_deps, starting_nodes))
+    return CondaEnvFileGenerator(get_installable_packages(build_commands, external_deps, starting_nodes), channels)
 
 def construct_build_tree(args):
     '''

--- a/open_ce/conda_env_file_generator.py
+++ b/open_ce/conda_env_file_generator.py
@@ -29,13 +29,14 @@ class CondaEnvFileGenerator():
 
     def __init__(self,
                  dependencies,
+                 channels
                  ):
         self._dependency_set = dependencies
+        self._channels = channels
 
     #pylint: disable=too-many-arguments
     def write_conda_env_file(self,
                              variant_string,
-                             channels=None,
                              output_folder=None,
                              env_file_prefix=utils.CONDA_ENV_FILENAME_PREFIX,
                              path=utils.DEFAULT_OUTPUT_FOLDER,
@@ -55,7 +56,7 @@ class CondaEnvFileGenerator():
         conda_env_file = conda_env_name + ".yaml"
         conda_env_file = os.path.join(path, conda_env_file)
 
-        channels = _create_channels(channels, output_folder)
+        channels = _create_channels(self._channels, output_folder)
 
         data = dict(
             name = conda_env_name,

--- a/tests/conda_env_file_generator_test.py
+++ b/tests/conda_env_file_generator_test.py
@@ -91,21 +91,21 @@ def test_conda_env_file_content():
     '''
     Tests that the conda env file content are being populated correctly
     '''
-    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), external_deps, starting_nodes=[list(sample_build_commands().nodes)[0]])
+    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), external_deps, [], starting_nodes=[list(sample_build_commands().nodes)[0]])
     expected_deps = set(["python >=3.6", "pack1 1.0.*", "pack2 >=2.0", "package1a 1.0.* py36_cuda10.2", "package1b 1.0.* py36_cuda10.2",
                          "pack3 9b", "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
-    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), [], starting_nodes=[list(sample_build_commands().nodes)[1]])
+    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), [], [], starting_nodes=[list(sample_build_commands().nodes)[1]])
     expected_deps = set(["python ==3.6.*", "pack1 >=1.0", "pack2 ==2.0.*", "package2a 1.0.* py36_cuda10.2", "pack3 3.3.* build"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
-    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), external_deps, starting_nodes=[list(sample_build_commands().nodes)[2]])
+    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), external_deps, [], starting_nodes=[list(sample_build_commands().nodes)[2]])
     expected_deps = set(["python 3.7.*", "pack1==1.0.*", "pack2 <=2.0", "pack3 3.0.*", "package3a 1.0.* py37_cuda10.2", "package3b 1.0.* py37_cuda10.2",
                      "pack4=1.15.0=py38h6ffa863_0", "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
-    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), [], starting_nodes=[list(sample_build_commands().nodes)[3]])
+    mock_conda_env_file_generator = build_tree.get_conda_file_packages(sample_build_commands(), [], [], starting_nodes=[list(sample_build_commands().nodes)[3]])
     expected_deps = set(["pack1==1.0.*", "pack2 <=2.0", "pack3-suffix 3.0.*", "package4a 1.0.* py37_cuda", "package4b 1.0.* py37_cuda"])
     assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any tests to validate this change?

## Description

Currently, channels added within an Open-CE environment file are not added to the generated conda environment files. This PR fixes that.

Also fixed an issue with checking the version podman. Sometimes the version string can have "-dev" in it.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
