### PR TITLE
Allow URLs for conda_build_configs in environment files

### DIFF
--- a/doc/README.yaml.md
+++ b/doc/README.yaml.md
@@ -266,11 +266,12 @@ be used to build the environment. These files will be passed to `conda-build` af
 values provided by the `--conda_build_configs` argument, as well as after the default
 locations for conda_build_config files. This will give conda_build_config files
 specified within an Open-CE file higher priority than those passed in through arguments
-and through default locations.
+and through default locations. Using URLs for `conda_build_configs` is also supported.
 
 ```yaml
 conda_build_configs:
   - my_conda_build_config.yaml
+  - https://my.url.org/my_conda_config.yaml
 ```
 
 ### git_tag_for_env

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -278,7 +278,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         # Find all conda_build_configs listed in environment files
         conda_build_configs = []
         for env_config_data in env_config_data_list:
-            conda_build_configs += [utils.expanded_path(config,
+            conda_build_configs += [ utils.download_file(config) if utils.is_url(config) else
+                                        utils.expanded_path(config,
                                         relative_to=env_config_data[env_config.Key.opence_env_file_path.name])
                                             for config in env_config_data.get(env_config.Key.conda_build_configs.name,
                                                                               [])]

--- a/tests/test-env1.yaml
+++ b/tests/test-env1.yaml
@@ -34,3 +34,4 @@ external_dependencies:
 
 conda_build_configs:
     - conda_build_config2.yaml
+    - https://raw.githubusercontent.com/open-ce/open-ce-builder/main/tests/conda_build_config.yaml


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any tests to validate this change?

## Description

This PR allows URLs to be used within the `conda_build_configs` flag within an Open-CE environment file.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
