### PR TITLE
Pass url to feedstock

### DIFF
--- a/open_ce/build_feedstock.py
+++ b/open_ce/build_feedstock.py
@@ -129,7 +129,10 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments, 
             config.skip_existing = False
             config.prefix_length = 225
             config.output_folder = output_folder
-            config.variant_config_files = [config for config in command.conda_build_configs if os.path.exists(config)]
+            conda_build_configs = [utils.download_file(conda_build_config) if utils.is_url(conda_build_config)
+                                       else conda_build_config
+                                           for conda_build_config in command.conda_build_configs]
+            config.variant_config_files = [config for config in conda_build_configs if os.path.exists(config)]
 
             if pkg_format == "conda":
                 config.conda_pkg_format = "2"     # set to .conda format

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -278,8 +278,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         # Find all conda_build_configs listed in environment files
         conda_build_configs = []
         for env_config_data in env_config_data_list:
-            conda_build_configs += [ utils.download_file(config) if utils.is_url(config) else
-                                        utils.expanded_path(config,
+            conda_build_configs += [config if utils.is_url(config) else utils.expanded_path(config,
                                         relative_to=env_config_data[env_config.Key.opence_env_file_path.name])
                                             for config in env_config_data.get(env_config.Key.conda_build_configs.name,
                                                                               [])]
@@ -328,7 +327,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                                   runtime_package,
                                   feedstock.get(env_config.Key.recipe_path.name),
                                   feedstock.get(env_config.Key.recipes.name),
-                                  [os.path.abspath(config) for config in conda_build_configs],
+                                  [config if utils.is_url(config) else os.path.abspath(config) for config in conda_build_configs],
                                   variants,
                                   channels)
         return retval
@@ -535,8 +534,8 @@ def _create_commands(repository, runtime_package, recipe_path,
     os.chdir(repository)
 
     config_data, _ = build_feedstock.load_package_config(variants=variants, recipe_path=recipe_path)
-    combined_config_files = variant_config_files
-
+    combined_config_files = [utils.download_file(config) if utils.is_url(config) else config
+                                 for config in variant_config_files]
     feedstock_conda_build_config_file = build_feedstock.get_conda_build_config()
     if feedstock_conda_build_config_file:
         combined_config_files.append(feedstock_conda_build_config_file)

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -327,7 +327,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                                   runtime_package,
                                   feedstock.get(env_config.Key.recipe_path.name),
                                   feedstock.get(env_config.Key.recipes.name),
-                                  [config if utils.is_url(config) else os.path.abspath(config) for config in conda_build_configs],
+                                  [config if utils.is_url(config) else os.path.abspath(config)
+                                      for config in conda_build_configs],
                                   variants,
                                   channels)
         return retval


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The full URL for a conda_build_config file should be passed to the `build_feedstock` command, instead of the path to the file that was downloaded. This is needed in case the `build_feedstock` command is run on a different image than the original `open-ce build env` command.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
