### PR TITLE
Allow versions to be integers

### DIFF
--- a/open_ce/get_licenses.py
+++ b/open_ce/get_licenses.py
@@ -66,7 +66,7 @@ class Key(Enum):
 
 _THIRD_PARTY_PACKAGE_SCHEMA ={
     Key.name.name: utils.make_schema_type(str, True),
-    Key.version.name: utils.make_schema_type(str, True),
+    Key.version.name: utils.make_schema_type((str, int, float), True),
     Key.license.name: utils.make_schema_type(str, True),
     Key.url.name: utils.make_schema_type([str], True),
     Key.license_url.name: utils.make_schema_type(str),
@@ -90,7 +90,7 @@ class LicenseGenerator():
         #pylint: disable=too-many-arguments
         def __init__(self, name, version, url=None, license_type=None, copyrights=None, license_files=None):
             self.name = name
-            self.version = version
+            self.version = str(version)
             self.url = url if isinstance(url, list) else [url]
             self.license_type = _clean_license_type(license_type) if license_type else license_type
             self.license_files = license_files if license_files else []

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -122,7 +122,7 @@ def test_add_licenses_from_info_file(mocker, capfd):
 
     print(license_contents)
     assert "DefinitelyTyped.google.analytics\tebc69904eb78f94030d5d517b42db20867f679c0\thttps://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts\tMIT\tCopyright Jed Mao <https://github.com/jedmao/>,, Copyright Bart van der Schoor <https://github.com/Bartvds>,, Copyright Andrew Brown <https://github.com/AGBrown>,, Copyright Olivier Chevet <https://github.com/olivr70>" in license_contents
-    assert "bad_url\t1.2.3\tnot_a_url.tar.gz\tNO_LICENSE\tNot a real copy right" in license_contents
+    assert "bad_url\t123\tnot_a_url.tar.gz\tNO_LICENSE\tNot a real copy right" in license_contents
     assert "google-test\t1.7.0\thttps://github.com/google/googletest/archive/release-1.7.0.zip\tBSD-equivalent\tCopyright 2008, Google Inc. All rights reserved." in license_contents
     assert "kissfft\t36dbc057604f00aacfc0288ddad57e3b21cfc1b8\thttps://github.com/mborgerding/kissfft/archive/36dbc057604f00aacfc0288ddad57e3b21cfc1b8.tar.gz\tBSD-equivalent\tCopyright (c) 2003-2010 Mark Borgerding . All rights reserved." in license_contents
 

--- a/tests/test-open-ce-info-1.yaml
+++ b/tests/test-open-ce-info-1.yaml
@@ -34,5 +34,5 @@ third_party_packages:
   license: NO_LICENSE
   url:
     - not_a_url.tar.gz
-  version: 1.2.3
+  version: 123
   copyright_string: "Not a real copy right"


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any tests to validate this change?

## Description

Allows the version field in an open-ce-info.yaml file to be an integer.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
