### PR TITLE
Add the resources flag to a build_command

### DIFF
--- a/open_ce/build_command.py
+++ b/open_ce/build_command.py
@@ -42,6 +42,7 @@ class BuildCommand():
                  build_dependencies=None,
                  test_dependencies=None,
                  channels=None,
+                 resources=None,
                  conda_build_configs=None):
         self.recipe = recipe
         self.repository = repository
@@ -60,6 +61,7 @@ class BuildCommand():
         self.test_dependencies = test_dependencies
         self.channels = channels if channels else []
         self.conda_build_configs = conda_build_configs
+        self.resources = resources
 
     def feedstock_args(self):
         """

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -577,6 +577,7 @@ def _create_commands(repository, runtime_package, recipe_path,
                                     build_dependencies=build_deps,
                                     test_dependencies=test_deps,
                                     channels=channels,
+                                    resources=recipe.get('resources'),
                                     conda_build_configs=variant_config_files)
         package_node = DependencyNode(set(packages), build_command)
         retval.add_node(package_node)

--- a/tests/my_config.yaml
+++ b/tests/my_config.yaml
@@ -4,4 +4,6 @@ recipes:
   - name : my_variant
     path: cuda_recipe_path #[build_type == 'cuda']
     path: cpu_recipe_path #[build_type == 'cpu' ]
+    resources:
+      memory: 200Gi
 {% endif %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Allow a build-config.yaml file to contain a "resources" field. This can list resources that are required to build the package, which will be stored within a `BuildCommand`.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
