### PR TITLE
Remove duplicate channels in _create_remote_deps

### DIFF
--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -344,16 +344,23 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                 node = deps.pop()
                 ancestor_build_cmds = {x.build_command for x in networkx.ancestors(dep_graph, node)
                                                                 if x.build_command is not None}
+                channels = node.channels
+
                 ancestor_channels = []
                 for cmd in ancestor_build_cmds:
                     ancestor_channels += cmd.channels
+
+                for channel in ancestor_channels + self._channels:
+                    if not channel in channels:
+                        channels += [channel]
+
                 for package in node.packages:
                     package_name = utils.remove_version(package)
                     if package_name in seen:
                         continue
                     seen.add(package_name)
                     # Pass in channels ordered by priority.
-                    package_info = conda_utils.get_latest_package_info(node.channels + ancestor_channels + self._channels,
+                    package_info = conda_utils.get_latest_package_info(channels,
                                                                        package)
                     # package_info is empty for a virtual package.
                     # As of now, this is just one case of package_info being empty.

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -344,13 +344,13 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                 node = deps.pop()
                 ancestor_build_cmds = {x.build_command for x in networkx.ancestors(dep_graph, node)
                                                                 if x.build_command is not None}
-                channels = node.channels
+                channels = []
 
                 ancestor_channels = []
                 for cmd in ancestor_build_cmds:
                     ancestor_channels += cmd.channels
 
-                for channel in ancestor_channels + self._channels:
+                for channel in node.channels + ancestor_channels + self._channels:
                     if not channel in channels:
                         channels += [channel]
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Duplicate channels were being passed to the `get_latest_package_info` function, which could sometimes make creating a BuildTree take a long time when passing in channels to `open-ce build env`. These changes remove duplicate channels, while still preserving the order of the channels.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
