### PR TITLE
Fix check build numbers when there are multiple outputs in a recipe

### DIFF
--- a/tests/feedstock_tests/check_build_numbers.py
+++ b/tests/feedstock_tests/check_build_numbers.py
@@ -40,18 +40,18 @@ def main(arg_strings=None):
 
     variant_build_results = dict()
     for variant in variants:
-        utils.run_and_log("git checkout {}".format(default_branch))
-        main_build_config_data, main_config = get_configs(variant, args.conda_build_configs)
-        if main_build_config_data["recipes"] is None:
-            continue
-        main_build_numbers = get_build_numbers(main_build_config_data, main_config, variant)
-
         utils.run_and_log("git checkout {}".format(pr_branch))
         pr_build_config_data, pr_config = get_configs(variant, args.conda_build_configs)
         if pr_build_config_data["recipes"] is None:
             continue
 
         current_pr_build_numbers = get_build_numbers(pr_build_config_data, pr_config, variant)
+
+        utils.run_and_log("git checkout {}".format(default_branch))
+        main_build_config_data, main_config = get_configs(variant, args.conda_build_configs)
+        if main_build_config_data["recipes"] is None:
+            continue
+        main_build_numbers = get_build_numbers(main_build_config_data, main_config, variant)
 
         print("Build Info for Variant:   {}".format(variant))
         print("Current PR Build Info:    {}".format(current_pr_build_numbers))

--- a/tests/feedstock_tests_test.py
+++ b/tests/feedstock_tests_test.py
@@ -73,14 +73,16 @@ def test_check_build_numbers():
     # Verify that check passes when version is the same, and build number increases
     check_build_numbers.main(["--python_versions", "2.3", "--build_types", "cuda"])
 
+    utils.run_and_log("git checkout new_test_branch")
     # Verify that check fails when version is the same, and build number is the same.
     with pytest.raises(AssertionError) as exc:
         check_build_numbers.main(["--python_versions", "2.3", "--build_types", "cpu"])
     assert "At least one package needs to increase the build number or change the version in at least one variant." in str(exc.value)
-
+    utils.run_and_log("git checkout new_test_branch")
     # Verify that check passes when version increases and build number goes back to 1.
     check_build_numbers.main(["--python_versions", "2.4", "--build_types", "cpu"])
 
+    utils.run_and_log("git checkout new_test_branch")
     # Verify that check passes when version increase and build number stays the same.
     check_build_numbers.main(["--python_versions", "2.4", "--build_types", "cuda"])
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
check_build_numbers.py had issues with some of the recipes like xgboost, LightGBM, pyarrow which have multiple outputs. This issue is visible when we change the versions and reset build number to 1.
Changing the order in which we retrieve build numbers/name/version from main branch and PR branch affects the results. If I retrieve PR branch info first before main branch, conda_build.api.render_yaml gives proper results. Otherwise the versions retrieved from PR branch are received as that on the main branch. (For e.g. main branch has 1.0 and PR branch has 2.0, then earlier it used to give 1.0 for both the branches).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
