### PR TITLE
Make GCC 11 as default compiler for P10 builds

### DIFF
--- a/open_ce/images/builder/Dockerfile-p10
+++ b/open_ce/images/builder/Dockerfile-p10
@@ -31,7 +31,7 @@ RUN export ARCH="$(uname -m)" && \
     mkdir -p $CONDA_HOME/conda-bld && \
     mkdir -p $HOME/.cache && \
     echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
-    export PATH="/opt/rh/gcc-toolset-10/root/usr/bin:${PATH}" && \
+    export PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}" && \
     export GCC_10_HOME="/opt/rh/gcc-toolset-10/root/usr" && \
     export GCC_11_HOME="/opt/rh/gcc-toolset-11/root/usr" && \
     echo "PATH="${PATH}"" >> ${HOME}/.profile && \
@@ -41,7 +41,7 @@ RUN export ARCH="$(uname -m)" && \
     chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME}
 
 USER ${BUILD_USER}
-RUN export PATH="/opt/rh/gcc-toolset-10/root/usr/bin:${PATH}" && \
+RUN export PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}" && \
     export GCC_10_HOME="/opt/rh/gcc-toolset-10/root/usr" && \
     export GCC_11_HOME="/opt/rh/gcc-toolset-11/root/usr" && \
     echo "PATH="${PATH}"" >> ${HOME}/.profile && \

--- a/open_ce/inputs.py
+++ b/open_ce/inputs.py
@@ -382,17 +382,17 @@ def _check_ppc_arch(args):
         if args.ppc_arch == "p10":
             if "GCC_10_HOME" not in os.environ:
                 os.environ["GCC_10_HOME"] = utils.DEFAULT_GCC_10_HOME_DIR
-            if os.path.exists(os.environ["GCC_10_HOME"]):
-                PATH = os.environ["PATH"]
-                os.environ["PATH"] = "{0}:{1}".format(os.path.join(os.environ["GCC_10_HOME"], "bin"), PATH)
-                print("Path variable set to : ", os.environ["PATH"])
-            else:
+            if not os.path.exists(os.environ["GCC_10_HOME"]):
                 raise OpenCEError(Error.GCC10_11_COMPILER_NOT_FOUND)
 
             if "GCC_11_HOME" not in os.environ:
                 os.environ["GCC_11_HOME"] = utils.DEFAULT_GCC_11_HOME_DIR
+                PATH = os.environ["PATH"]
+                os.environ["PATH"] = "{0}:{1}".format(os.path.join(os.environ["GCC_11_HOME"], "bin"), PATH)
+                print("Path variable set to : ", os.environ["PATH"])
             if not os.path.exists(utils.DEFAULT_GCC_11_HOME_DIR):
                 raise OpenCEError(Error.GCC10_11_COMPILER_NOT_FOUND)
+
 
 def parse_args(parser, arg_strings=None):
     '''


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

GCC 10 is needed only for TF IO due to boringssl (the version of boringssl used in TFIO ) not being compatible with GCC 11.
For all the recipes, we will use GCC 11 as a default compiler.
I'll close my previous PR https://github.com/open-ce/open-ce-builder/pull/119 which removes GCC 10 completely from Dockerfiles and builder code. 


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
