### PR TITLE
fix to support latest conda-build version

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python
     - setuptools
   run:
-    - conda-build 3.21.7
+    - conda-build
     - networkx
     - pyyaml
     - requests

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -315,7 +315,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         #commands = utils.run_in_parallel(self._create_commands_helper, create_commands_args)
         commands = []
         for variant, env_config_data, conda_build_configs, feedstock in create_commands_args:
-             commands.append(self._create_commands_helper(variant, env_config_data, conda_build_configs, feedstock))
+            commands.append(self._create_commands_helper(variant, env_config_data, conda_build_configs, feedstock))
 
         # Add the results of _create_commands_helper to the graph
         for command in commands:

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -310,8 +310,12 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             if current_deps:
                 external_deps += current_deps
 
-        # Execute _create_commands_helper in parallel
-        commands = utils.run_in_parallel(self._create_commands_helper, create_commands_args)
+        # Execute _create_commands_helper in parallel is resulting into error with conda-build v3.21.8
+        # So switching to non-parallel approach.
+        #commands = utils.run_in_parallel(self._create_commands_helper, create_commands_args)
+        commands = []
+        for variant, env_config_data, conda_build_configs, feedstock in create_commands_args:
+             commands.append(self._create_commands_helper(variant, env_config_data, conda_build_configs, feedstock))
 
         # Add the results of _create_commands_helper to the graph
         for command in commands:

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -455,9 +455,9 @@ def test_system_exit(mocker):
     mocker.patch("open_ce.build_tree.BuildTree._get_repo", side_effect=SystemExit(1))
 
     arg_strings = ["build", build_env.COMMAND, "tests/test-env1.yaml"]
-    with pytest.raises(OpenCEError) as exc:
+    with pytest.raises(SystemExit) as exc:
         opence._main(arg_strings)
-    assert "Unexpected Error: 1" in str(exc.value)
+    assert "SystemExit(1)" in str(exc)
 
 def test_run_tests(mocker):
     '''


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Use non-parallel execution while creating BuildCommands to avoid the following error with conda-build v3.21.8:
```
HEAD is now at 64ee0c0 use py39 in github action (#25)
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/shutil.py", line 806, in move
    os.rename(src, real_dst)
FileNotFoundError: [Errno 2] No such file or directory: '/opt/conda/conda-bld/work' -> '/opt/conda/conda-bld/spacy_1652933012637/work'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/opt/conda/lib/python3.9/multiprocessing/pool.py", line 51, in starmapstar
    return list(itertools.starmap(args[0], args[1]))
  File "<myhome>open-ce-builder/open_ce/utils.py", line 384, in _run_helper
    return func(*args, **kwargs)
  File "<myhome>open-ce-builder/open_ce/build_tree.py", line 327, in _create_commands_helper
    retval = _create_commands(repo_dir,
  File "<myhome>open-ce-builder/open_ce/build_tree.py", line 567, in _create_commands
    packages, version, run_deps, host_deps, build_deps, test_deps, output_files = _get_package_dependencies(
  File "<myhome>open-ce-builder/open_ce/build_tree.py", line 130, in _get_package_dependencies
    metas = conda_utils.render_yaml(path, variants, variant_config_files)
  File "<myhome>open-ce-builder/open_ce/conda_utils.py", line 53, in render_yaml
    metas = conda_build.api.render(path,
  File "/opt/conda/lib/python3.9/site-packages/conda_build/api.py", line 42, in render
    metadata_tuples = render_recipe(recipe_path, bypass_env_check=bypass_env_check,
  File "/opt/conda/lib/python3.9/site-packages/conda_build/render.py", line 838, in render_recipe
    m.config.compute_build_id(m.name(), m.version(), reset=reset_build_id)
  File "/opt/conda/lib/python3.9/site-packages/conda_build/config.py", line 611, in compute_build_id
    shutil.move(old_dir, work_dir)
  File "/opt/conda/lib/python3.9/shutil.py", line 826, in move
    copy_function(src, real_dst)
  File "/opt/conda/lib/python3.9/shutil.py", line 435, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/opt/conda/lib/python3.9/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: '/opt/conda/conda-bld/work'
```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
