### PR TITLE
Added glibc-devel in cpu Dockerfiles

### DIFF
--- a/open_ce/images/builder/Dockerfile
+++ b/open_ce/images/builder/Dockerfile
@@ -12,7 +12,7 @@ ENV BUILD_USER=builder
 ARG BUILD_ID=1084
 
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y rsync openssh-clients diffutils procps binutils git-lfs && \
+    yum repolist && yum install -y rsync openssh-clients diffutils procps binutils git-lfs glibc-devel && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder

--- a/open_ce/images/builder/Dockerfile-p10
+++ b/open_ce/images/builder/Dockerfile-p10
@@ -12,7 +12,7 @@ ENV BUILD_USER=builder
 ARG BUILD_ID=1084
 
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y rsync openssh-clients diffutils procps git-lfs gcc-toolset-10 gcc-toolset-11 && \
+    yum repolist && yum install -y rsync openssh-clients diffutils procps git-lfs gcc-toolset-10 gcc-toolset-11 glibc-devel && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

glibc-devel provides /usr/lib64/libpthread_nonshared.a file which is needed by linker. This package glibc-devel is present on cuda images by default but was missing on cpu images. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
