### PR TITLE
Fixed auto-tagging for envs which are cpu only

### DIFF
--- a/git_tools/create_opence_release.py
+++ b/git_tools/create_opence_release.py
@@ -90,8 +90,12 @@ def _main(arg_strings=None): # pylint: disable=too-many-locals, too-many-stateme
     release_name = f"v{version}"
 
     tf_serving_env = os.path.abspath(os.path.join(primary_repo_path, "envs", "tensorflow-serving-env.yaml"))
-    env_file_contents = env_config.load_env_config_files([open_ce_env_file, tf_serving_env],
-                                                          utils.ALL_VARIANTS(), ignore_urls=True)
+    variants = utils.ALL_VARIANTS()
+    print("Variants: ", variants)
+    env_file_contents = []
+    for variant in variants:
+        env_file_contents += env_config.load_env_config_files([open_ce_env_file, tf_serving_env],
+                                                          [variant], ignore_urls=True)
     for env_file_content in env_file_contents:
         env_file_tag = env_file_content.get(env_config.Key.git_tag_for_env.name, None)
         if env_file_tag != current_tag:

--- a/git_tools/create_opence_release.py
+++ b/git_tools/create_opence_release.py
@@ -64,7 +64,7 @@ def _make_parser():
 
     return parser
 
-def _main(arg_strings=None): # pylint: disable=too-many-locals, too-many-statements
+def _main(arg_strings=None): # pylint: disable=too-many-locals, too-many-statements, too-many-branches
     parser = _make_parser()
     args = parser.parse_args(arg_strings)
 
@@ -91,7 +91,6 @@ def _main(arg_strings=None): # pylint: disable=too-many-locals, too-many-stateme
 
     tf_serving_env = os.path.abspath(os.path.join(primary_repo_path, "envs", "tensorflow-serving-env.yaml"))
     variants = utils.ALL_VARIANTS()
-    print("Variants: ", variants)
     env_file_contents = []
     for variant in variants:
         env_file_contents += env_config.load_env_config_files([open_ce_env_file, tf_serving_env],


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

For envs, which are cpu only, were being skipped from auto-tagging. https://github.com/open-ce/open-ce-builder/issues/149

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
