### PR TITLE
Install libtirpc-devel needed for TF IO package

### DIFF
--- a/open_ce/images/builder/Dockerfile-p10
+++ b/open_ce/images/builder/Dockerfile-p10
@@ -12,7 +12,7 @@ ENV BUILD_USER=builder
 ARG BUILD_ID=1084
 
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y rsync openssh-clients diffutils procps git-lfs gcc-toolset-11 glibc-devel file && \
+    yum repolist && yum install -y rsync openssh-clients diffutils procps git-lfs gcc-toolset-11 glibc-devel file libtirpc-devel && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

TF IO 0.27.0 failed for P10 due to unavailability of `rpc/types.h`. This header file is usually provided by Anaconda's compilers. However, for P10 build, we don't use Anaconda's compiler, and instead use Redhat's GCC 11 which doesn't have this header file. This header file is also part of Redhat's libtirpc-devel package. So, we need to install this package in P10 Docker image.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
