### PR TITLE
Refactoring and fixed issue with different hash for the same package

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -139,7 +139,6 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        cyclic-import,
         invalid-name
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - jinja2
     - python
     - git
-    - matplotlib
+    - matplotlib 3.5.*
     - junit-xml
 
 test:

--- a/git_tools/apply_patches.py
+++ b/git_tools/apply_patches.py
@@ -23,12 +23,13 @@ import pathlib
 import git_utils
 
 sys.path.append(os.path.join(pathlib.Path(__file__).parent.absolute(), '..'))
-from open_ce import inputs # pylint: disable=wrong-import-position
+from open_ce.inputs import make_parser as inputs_make_parser # pylint: disable=wrong-import-position
+from open_ce.utils import parse_arg_list # pylint: disable=wrong-import-position
 
 
 def make_parser():
     ''' Parser input arguments '''
-    parser = inputs.make_parser([git_utils.Argument.PUBLIC_ACCESS_TOKEN, git_utils.Argument.REPO_DIR,
+    parser = inputs_make_parser([git_utils.Argument.PUBLIC_ACCESS_TOKEN, git_utils.Argument.REPO_DIR,
                                     git_utils.Argument.BRANCH, git_utils.Argument.ORG, git_utils.Argument.SKIPPED_REPOS,
                                     git_utils.Argument.REVIEWERS, git_utils.Argument.TEAM_REVIEWERS,
                                     git_utils.Argument.PARAMS],
@@ -58,13 +59,13 @@ def _main(arg_strings=None):
     parser = make_parser()
     args = parser.parse_args(arg_strings)
 
-    skipped_repos = inputs.parse_arg_list(args.skipped_repos)
+    skipped_repos = parse_arg_list(args.skipped_repos)
     repos = git_utils.get_all_repos(args.github_org, args.pat)
     repos = [repo for repo in repos if repo["name"] not in skipped_repos]
 
     param_dict = {param.split(":")[0]: param.split(":")[1] for param in args.params}
 
-    patches = [os.path.abspath(arg_file) for arg_file in inputs.parse_arg_list(args.patches)]
+    patches = [os.path.abspath(arg_file) for arg_file in parse_arg_list(args.patches)]
     for repo in repos:
         try:
             print("Beginning " + repo["name"] + "---------------------------")
@@ -99,8 +100,8 @@ def _main(arg_strings=None):
                                         repo["name"],
                                         args.pat,
                                         created_pr["number"],
-                                        inputs.parse_arg_list(args.reviewers),
-                                        inputs.parse_arg_list(args.team_reviewers))
+                                        parse_arg_list(args.reviewers),
+                                        parse_arg_list(args.team_reviewers))
 
             print("---------------------------" + "Finished " + repo["name"])
         except Exception as exc:# pylint: disable=broad-except

--- a/git_tools/create_opence_release.py
+++ b/git_tools/create_opence_release.py
@@ -32,16 +32,17 @@ import tag_all_repos
 from create_version_branch import _get_repo_version
 
 sys.path.append(os.path.join(pathlib.Path(__file__).parent.absolute(), '..'))
-from open_ce import inputs # pylint: disable=wrong-import-position
+from open_ce.inputs import Argument, make_parser # pylint: disable=wrong-import-position
+from open_ce.utils import parse_arg_list # pylint: disable=wrong-import-position
 from open_ce import env_config # pylint: disable=wrong-import-position
-from open_ce import utils # pylint: disable=wrong-import-position
+from open_ce import utils, constants # pylint: disable=wrong-import-position
 from open_ce.conda_utils import render_yaml # pylint: disable=wrong-import-position
 
 def _make_parser():
     ''' Parser input arguments '''
-    parser = inputs.make_parser([git_utils.Argument.PUBLIC_ACCESS_TOKEN, git_utils.Argument.REPO_DIR,
+    parser = make_parser([git_utils.Argument.PUBLIC_ACCESS_TOKEN, git_utils.Argument.REPO_DIR,
                                     git_utils.Argument.BRANCH, git_utils.Argument.SKIPPED_REPOS,
-                                    git_utils.Argument.NOT_DRY_RUN, inputs.Argument.CONDA_BUILD_CONFIG],
+                                    git_utils.Argument.NOT_DRY_RUN, Argument.CONDA_BUILD_CONFIG],
                                     description = 'A script that can be used to cut an open-ce release.')
 
     parser.add_argument(
@@ -122,7 +123,7 @@ def _main(arg_strings=None): # pylint: disable=too-many-locals, too-many-stateme
     repos = _get_all_feedstocks(env_files=env_file_contents,
                                 github_org=args.github_org,
                                 pat=args.pat,
-                                skipped_repos=[args.primary_repo, ".github"] + inputs.parse_arg_list(args.skipped_repos))
+                                skipped_repos=[args.primary_repo, ".github"] + parse_arg_list(args.skipped_repos))
 
     repos.sort(key=lambda repo: repo["name"])
 
@@ -258,7 +259,7 @@ def _create_release_notes(repos, version, release_number, bug_fix, current_tag, 
         print("Error trying to get package versions: ", exc)
     retval += "\n"
     retval += "This release of Open-CE supports NVIDIA's CUDA "
-    retval += f"versions {utils.SUPPORTED_CUDA_VERS} as well as Python {utils.SUPPORTED_PYTHON_VERS}.\n"
+    retval += f"versions {constants.SUPPORTED_CUDA_VERS} as well as Python {constants.SUPPORTED_PYTHON_VERS}.\n"
     retval += "\n"
     retval += "## Getting Started"
     retval += "\n"

--- a/git_tools/create_version_branch.py
+++ b/git_tools/create_version_branch.py
@@ -40,6 +40,7 @@ from open_ce import inputs
 from open_ce import conda_utils
 from open_ce import build_feedstock
 from open_ce import utils
+
 def _make_parser():
     ''' Parser input arguments '''
     parser = inputs.make_parser([git_utils.Argument.REPO_DIR, inputs.Argument.CONDA_BUILD_CONFIG],

--- a/git_tools/create_version_branch.py
+++ b/git_tools/create_version_branch.py
@@ -40,7 +40,6 @@ from open_ce import inputs
 from open_ce import conda_utils
 from open_ce import build_feedstock
 from open_ce import utils
-
 def _make_parser():
     ''' Parser input arguments '''
     parser = inputs.make_parser([git_utils.Argument.REPO_DIR, inputs.Argument.CONDA_BUILD_CONFIG],

--- a/git_tools/tag_all_repos.py
+++ b/git_tools/tag_all_repos.py
@@ -39,11 +39,12 @@ import pathlib
 import git_utils
 
 sys.path.append(os.path.join(pathlib.Path(__file__).parent.absolute(), '..'))
-from open_ce import inputs # pylint: disable=wrong-import-position
+from open_ce.inputs import make_parser # pylint: disable=wrong-import-position
+from open_ce.utils import parse_arg_list # pylint: disable=wrong-import-position
 
 def _make_parser():
     ''' Parser input arguments '''
-    parser = inputs.make_parser([git_utils.Argument.PUBLIC_ACCESS_TOKEN, git_utils.Argument.REPO_DIR,
+    parser = make_parser([git_utils.Argument.PUBLIC_ACCESS_TOKEN, git_utils.Argument.REPO_DIR,
                                     git_utils.Argument.BRANCH, git_utils.Argument.ORG, git_utils.Argument.SKIPPED_REPOS],
                                     description = """
                                     Tag all repos in an organization using the following logic:
@@ -78,7 +79,7 @@ def tag_all_repos(github_org, tag, tag_msg, branch, repo_dir, pat, skipped_repos
     Clones, then tags all repos with a given tag, and pushes back to remote.
     These steps are performed in separate loops to make debugging easier.
     '''
-    skipped_repos = inputs.parse_arg_list(skipped_repos)
+    skipped_repos = parse_arg_list(skipped_repos)
     repos = git_utils.get_all_repos(github_org, pat)
     repos = [repo for repo in repos if repo["name"] in skipped_repos ]
 

--- a/open_ce/build_env.py
+++ b/open_ce/build_env.py
@@ -22,7 +22,6 @@ import sys
 from open_ce import build_feedstock
 from open_ce import container_build
 from open_ce import utils
-from open_ce import inputs
 from open_ce.inputs import Argument, ENV_BUILD_ARGS
 from open_ce import test_feedstock
 from open_ce.errors import OpenCEError, Error, log
@@ -104,6 +103,6 @@ def build_env(args):
                 log.info("Skipping build of %s because it already exists.", build_command.recipe)
 
     if args.run_tests:
-        _run_tests(build_tree, inputs.parse_arg_list(args.test_labels), conda_env_files, os.path.abspath(args.output_folder))
+        _run_tests(build_tree, utils.parse_arg_list(args.test_labels), conda_env_files, os.path.abspath(args.output_folder))
 
 ENTRY_FUNCTION = build_env

--- a/open_ce/build_feedstock.py
+++ b/open_ce/build_feedstock.py
@@ -20,7 +20,7 @@ import os
 import traceback
 
 from open_ce import utils, constants
-from open_ce import inputs, conda_utils
+from open_ce import inputs
 from open_ce.inputs import Argument
 from open_ce.errors import OpenCEError, Error, log
 from open_ce.build_command import BuildCommand
@@ -53,6 +53,8 @@ def load_package_config(config_file=None, variants=None, recipe_path=None, permi
     file as an argument, it will be assumed that there is only one
     recipe to build, and it is in the directory called 'recipe'.
     '''
+    # pylint: disable=import-outside-toplevel
+    from open_ce import conda_utils
 
     if recipe_path:
         recipe_name = os.path.basename(os.getcwd())
@@ -109,6 +111,7 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments, 
 
     # pylint: disable=import-outside-toplevel
     import conda_build.api
+    from open_ce import conda_utils  # pylint: disable=import-outside-toplevel
 
     saved_working_directory = None
     if command.repository:

--- a/open_ce/build_feedstock.py
+++ b/open_ce/build_feedstock.py
@@ -109,7 +109,6 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments, 
 
     # pylint: disable=import-outside-toplevel
     import conda_build.api
-    #from conda_build.config import get_or_merge_config
 
     saved_working_directory = None
     if command.repository:

--- a/open_ce/build_feedstock.py
+++ b/open_ce/build_feedstock.py
@@ -19,10 +19,11 @@
 import os
 import traceback
 
-from open_ce import utils
-from open_ce import inputs
+from open_ce import utils, constants
+from open_ce import inputs, conda_utils
 from open_ce.inputs import Argument
 from open_ce.errors import OpenCEError, Error, log
+from open_ce.build_command import BuildCommand
 
 COMMAND = 'feedstock'
 
@@ -52,18 +53,16 @@ def load_package_config(config_file=None, variants=None, recipe_path=None, permi
     file as an argument, it will be assumed that there is only one
     recipe to build, and it is in the directory called 'recipe'.
     '''
-    # pylint: disable=import-outside-toplevel
-    from open_ce import conda_utils
 
     if recipe_path:
         recipe_name = os.path.basename(os.getcwd())
         build_config_data = {'recipes':[{'name':recipe_name, 'path':recipe_path}]}
-    elif not config_file and not os.path.exists(utils.DEFAULT_RECIPE_CONFIG_FILE):
+    elif not config_file and not os.path.exists(constants.DEFAULT_RECIPE_CONFIG_FILE):
         recipe_name = os.path.basename(os.getcwd())
         build_config_data = {'recipes':[{'name':recipe_name, 'path':'recipe'}]}
     else:
         if not config_file:
-            config_file = utils.DEFAULT_RECIPE_CONFIG_FILE
+            config_file = constants.DEFAULT_RECIPE_CONFIG_FILE
         if not os.path.exists(config_file):
             raise OpenCEError(Error.CONFIG_FILE, config_file)
 
@@ -98,9 +97,9 @@ def _set_local_src_dir(local_src_dir_arg, recipe, recipe_config_file):
 
 def build_feedstock_from_command(command, # pylint: disable=too-many-arguments, too-many-locals
                                  recipe_config_file=None,
-                                 output_folder=utils.DEFAULT_OUTPUT_FOLDER,
+                                 output_folder=constants.DEFAULT_OUTPUT_FOLDER,
                                  local_src_dir=None,
-                                 pkg_format=utils.DEFAULT_PKG_FORMAT,
+                                 pkg_format=constants.DEFAULT_PKG_FORMAT,
                                  debug=None,
                                  debug_output_id=None):
     '''
@@ -110,14 +109,14 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments, 
 
     # pylint: disable=import-outside-toplevel
     import conda_build.api
-    from conda_build.config import get_or_merge_config
+    #from conda_build.config import get_or_merge_config
 
     saved_working_directory = None
     if command.repository:
         saved_working_directory = os.getcwd()
         os.chdir(os.path.abspath(command.repository))
 
-    recipes_to_build = inputs.parse_arg_list(command.recipe)
+    recipes_to_build = utils.parse_arg_list(command.recipe)
 
     for variant in utils.make_variants(command.python, command.build_type, command.mpi_type, command.cudatoolkit):
         build_config_data, recipe_config_file  = load_package_config(recipe_config_file, variant, command.recipe_path)
@@ -130,7 +129,7 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments, 
             if recipes_to_build and recipe['name'] not in recipes_to_build:
                 continue
 
-            config = get_or_merge_config(None, variant=variant)
+            config = conda_utils.get_conda_config(variant)
             config.skip_existing = False
             config.prefix_length = 225
             config.output_folder = output_folder
@@ -176,10 +175,7 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments, 
 
 def build_feedstock(args):
     '''Entry Function'''
-    # Here, importing BuildCommand is intentionally done here to avoid circular import.
-
-    from open_ce.build_tree import BuildCommand   # pylint: disable=import-outside-toplevel
-    command = BuildCommand(recipe=inputs.parse_arg_list(args.recipe_list),
+    command = BuildCommand(recipe=utils.parse_arg_list(args.recipe_list),
                            repository=args.working_directory,
                            packages=[],
                            python=args.python_versions,

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -18,9 +18,9 @@
 
 import os
 import shutil
-from open_ce import utils
+from open_ce import utils, constants
 from open_ce import __version__ as open_ce_version
-from open_ce.inputs import Argument, parse_arg_list
+from open_ce.inputs import Argument
 from open_ce.errors import OpenCEError, Error, show_warning, log
 
 COMMAND = 'image'
@@ -46,7 +46,7 @@ def build_image(local_conda_channel, conda_env_file, container_tool, image_versi
     Build a container image from the Dockerfile in RUNTIME_IMAGE_PATH.
     Returns a result code and the name of the new image.
     """
-    variant = os.path.splitext(conda_env_file)[0].replace(utils.CONDA_ENV_FILENAME_PREFIX, "", 1)
+    variant = os.path.splitext(conda_env_file)[0].replace(constants.CONDA_ENV_FILENAME_PREFIX, "", 1)
     variant = variant.replace("-runtime", "")
     image_name = REPO_NAME + ":" + image_version + "-" + variant
     # Docker version on ppc64le rhel7 doesn't allow Dockerfiles to be out of build context.
@@ -106,7 +106,7 @@ def build_runtime_container_image(args):
 
     os.makedirs(os.path.join(local_conda_channel, TEMP_FILES), exist_ok=True)
 
-    for conda_env_file in parse_arg_list(args.conda_env_files):
+    for conda_env_file in utils.parse_arg_list(args.conda_env_files):
         conda_env_file = os.path.abspath(conda_env_file)
         if not os.path.exists(conda_env_file):
             raise OpenCEError(Error.INCORRECT_INPUT_PATHS)

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -21,18 +21,17 @@ import shutil
 
 import networkx
 
-from open_ce import utils
+from open_ce import utils, constants
 utils.check_if_package_exists('conda-build')
 
 # pylint: disable=wrong-import-position,wrong-import-order
 from open_ce import graph
 from open_ce import env_config
-from open_ce import validate_config
+from open_ce import validate_config     #pylint: disable=cyclic-import
 from open_ce import build_feedstock
 from open_ce.errors import OpenCEError, Error, log
 from open_ce.conda_env_file_generator import CondaEnvFileGenerator
 from open_ce.build_command import BuildCommand
-from open_ce import inputs
 # pylint: enable=wrong-import-position,wrong-import-order
 
 class DependencyNode():
@@ -178,8 +177,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                  cuda_versions,
                  repository_folder="./",
                  channels=None,
-                 git_location=utils.DEFAULT_GIT_LOCATION,
-                 git_tag_for_env=utils.DEFAULT_GIT_TAG,
+                 git_location=constants.DEFAULT_GIT_LOCATION,
+                 git_tag_for_env=constants.DEFAULT_GIT_TAG,
                  git_up_to_date=False,
                  conda_build_config=None,
                  packages=None):
@@ -247,7 +246,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         # If the feedstock value starts with any of the SUPPORTED_GIT_PROTOCOLS, treat it as a url. Otherwise
         # combine with git_location and append "-feedstock.git"
         feedstock_value = package[env_config.Key.feedstock.name]
-        if any(feedstock_value.startswith(protocol) for protocol in utils.SUPPORTED_GIT_PROTOCOLS):
+        if any(feedstock_value.startswith(protocol) for protocol in constants.SUPPORTED_GIT_PROTOCOLS):
             git_tag_for_package = package.get(env_config.Key.git_tag.name, None)
             if "open-ce" not in feedstock_value and not git_tag_for_package:
                 raise OpenCEError(Error.GIT_TAG_MISSING, feedstock_value)
@@ -463,7 +462,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
     def write_conda_env_files(self,
                               output_folder=None,
-                              env_file_prefix=utils.CONDA_ENV_FILENAME_PREFIX,
+                              env_file_prefix=constants.CONDA_ENV_FILENAME_PREFIX,
                               path=os.getcwd()):
         """
         Write a conda environment file for each variant.
@@ -688,14 +687,14 @@ def construct_build_tree(args):
 
     # Create the build tree
     return BuildTree(env_config_files=args.env_config_file,
-                     python_versions=inputs.parse_arg_list(args.python_versions),
-                     build_types=inputs.parse_arg_list(args.build_types),
-                     mpi_types=inputs.parse_arg_list(args.mpi_types),
-                     cuda_versions=inputs.parse_arg_list(args.cuda_versions),
+                     python_versions=utils.parse_arg_list(args.python_versions),
+                     build_types=utils.parse_arg_list(args.build_types),
+                     mpi_types=utils.parse_arg_list(args.mpi_types),
+                     cuda_versions=utils.parse_arg_list(args.cuda_versions),
                      repository_folder=args.repository_folder,
                      channels=args.channels_list,
                      git_location=args.git_location,
                      git_tag_for_env=args.git_tag_for_env,
                      git_up_to_date=args.git_up_to_date,
                      conda_build_config=args.conda_build_configs,
-                     packages=inputs.parse_arg_list(args.packages))
+                     packages=utils.parse_arg_list(args.packages))

--- a/open_ce/conda_env_file_generator.py
+++ b/open_ce/conda_env_file_generator.py
@@ -18,7 +18,7 @@
 
 import os
 
-from open_ce import utils
+from open_ce import constants
 
 #pylint: disable=too-few-public-methods
 class CondaEnvFileGenerator():
@@ -38,9 +38,9 @@ class CondaEnvFileGenerator():
     def write_conda_env_file(self,
                              variant_string,
                              output_folder=None,
-                             env_file_prefix=utils.CONDA_ENV_FILENAME_PREFIX,
-                             path=utils.DEFAULT_OUTPUT_FOLDER,
-                             git_tag_for_env=utils.DEFAULT_GIT_TAG):
+                             env_file_prefix=constants.CONDA_ENV_FILENAME_PREFIX,
+                             path=constants.DEFAULT_OUTPUT_FOLDER,
+                             git_tag_for_env=constants.DEFAULT_GIT_TAG):
         """
         This function writes conda environment files using the dependency dictionary
         created from all the buildcommands.
@@ -68,8 +68,8 @@ class CondaEnvFileGenerator():
             # And, main branch means the latest code, hence open-ce version string should be `latest`.
             git_tag_for_env = "latest"
         with open(conda_env_file, 'w', encoding='utf8') as outfile:
-            outfile.write("#" + utils.OPEN_CE_VARIANT + ":" + variant_string + "\n")
-            outfile.write("#" + utils.OPEN_CE_VERSION_STRING + ":" + git_tag_for_env + "\n" )
+            outfile.write("#" + constants.OPEN_CE_VARIANT + ":" + variant_string + "\n")
+            outfile.write("#" + constants.OPEN_CE_VERSION_STRING + ":" + git_tag_for_env + "\n" )
             open_ce.yaml_utils.dump(data, outfile, default_flow_style=False)
             file_name = conda_env_file
 
@@ -83,7 +83,7 @@ def get_variant_string(conda_env_file):
     with open(conda_env_file, 'r', encoding='utf8') as stream:
         first_line = stream.readline().strip()[1:]
         values = first_line.split(':')
-        if values[0] == utils.OPEN_CE_VARIANT:
+        if values[0] == constants.OPEN_CE_VARIANT:
             return values[1]
 
     return None

--- a/open_ce/conda_utils.py
+++ b/open_ce/conda_utils.py
@@ -89,7 +89,7 @@ def get_output_file_paths(meta, variants):
     """
     Get the paths of all of the generated packages for a recipe.
     """
-    config = get_or_merge_config(None, variant=variants)
+    config = get_conda_config(variants)
     config.verbose = False
 
     out_files = conda_build.api.get_output_file_paths(meta, config=config)

--- a/open_ce/constants.py
+++ b/open_ce/constants.py
@@ -1,0 +1,53 @@
+"""
+# *****************************************************************
+# (C) Copyright IBM Corp. 2022. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *****************************************************************
+"""
+import os
+
+DEFAULT_BUILD_TYPES = "cpu,cuda"
+SUPPORTED_BUILD_TYPES = DEFAULT_BUILD_TYPES
+DEFAULT_PYTHON_VERS = "3.10"
+SUPPORTED_PYTHON_VERS = "3.8,3.9,3.10"
+DEFAULT_MPI_TYPES = "openmpi"
+SUPPORTED_MPI_TYPES = "system,openmpi"
+DEFAULT_CUDA_VERS = "11.4"
+SUPPORTED_CUDA_VERS = "11.2,11.4"
+CONDA_BUILD_CONFIG_FILE = "conda_build_config.yaml"
+DEFAULT_CONDA_BUILD_CONFIG = os.path.abspath(os.path.join(os.getcwd(), CONDA_BUILD_CONFIG_FILE))
+DEFAULT_GIT_LOCATION = "https://github.com/open-ce"
+DEFAULT_ENVS_REPO = "open-ce"
+SUPPORTED_GIT_PROTOCOLS = ["https:", "http:", "git@"]
+DEFAULT_RECIPE_CONFIG_FILE = "config/build-config.yaml"
+CONDA_ENV_FILENAME_PREFIX = "opence-conda-env-"
+DEFAULT_OUTPUT_FOLDER = "condabuild"
+DEFAULT_TEST_CONFIG_FILE = "tests/open-ce-tests.yaml"
+DEFAULT_GIT_TAG = None
+OPEN_CE_VARIANT = "open-ce-variant"
+DEFAULT_TEST_WORKING_DIRECTORY = "./"
+KNOWN_VARIANT_PACKAGES = ["python", "cudatoolkit"]
+DEFAULT_LICENSES_FILE = "licenses.csv"
+TMP_LICENSE_DIR = "tmp_license_src"
+OPEN_CE_INFO_FILE = "open-ce-info.yaml"
+CONTAINER_TOOLS = ["podman", "docker"]
+DEFAULT_CONTAINER_TOOL = next(filter(lambda tool: os.system(f"which {tool} &> /dev/null")
+                                      == 0, CONTAINER_TOOLS), None)
+DEFAULT_PKG_FORMAT = "conda"  # use .conda output format
+NUM_THREAD_POOL = 16
+OPEN_CE_VERSION_STRING = "Open-CE Version"
+DEFAULT_GRAPH_FILE = "graph.png"
+DEFAULT_TEST_RESULT_FILE = "test_results.xml"
+DEFAULT_PPC_ARCH = "p9"
+DEFAULT_GCC_11_HOME_DIR = "/opt/rh/gcc-toolset-11/root/usr"

--- a/open_ce/container_build.py
+++ b/open_ce/container_build.py
@@ -21,7 +21,7 @@ import datetime
 import argparse
 import glob
 
-from open_ce import utils
+from open_ce import utils, constants
 from open_ce.errors import OpenCEError, Error
 from open_ce.inputs import Argument
 
@@ -60,7 +60,7 @@ def _home_path(container_tool):
 
 #pylint: disable=too-many-arguments
 def build_image(build_image_path, dockerfile, container_tool, cuda_version=None,
-                container_build_args="", ppc_arch=utils.DEFAULT_PPC_ARCH):
+                container_build_args="", ppc_arch=constants.DEFAULT_PPC_ARCH):
 
     """
     Build a container image from the Dockerfile in BUILD_IMAGE_PATH.
@@ -118,7 +118,7 @@ def _create_container(container_name, image_name, output_folder, env_folders, co
 
     # Add output folder
     container_cmd += _add_volume(os.path.abspath(output_folder),
-                              os.path.abspath(os.path.join(home_path, utils.DEFAULT_OUTPUT_FOLDER)))
+                              os.path.abspath(os.path.join(home_path, constants.DEFAULT_OUTPUT_FOLDER)))
 
     if container_tool == "docker":
         # Store temporary data in an anonymous volume
@@ -213,7 +213,7 @@ def build_in_container(image_name, args, arg_strings):
         # Cleanup
         _stop_container(container_name, args.container_tool)
 
-def _generate_dockerfile_name(build_types, cuda_version, ppc_arch=utils.DEFAULT_PPC_ARCH):
+def _generate_dockerfile_name(build_types, cuda_version, ppc_arch=constants.DEFAULT_PPC_ARCH):
     '''
     Ensure we have valid combinations.  I.e. Specify a valid cuda version
     '''
@@ -258,7 +258,7 @@ def build_with_container_tool(args, arg_strings):
     parser = make_parser()
     _, unused_args = parser.parse_known_args(arg_strings[1:])
     if not args.ppc_arch:
-        args.ppc_arch = utils.DEFAULT_PPC_ARCH
+        args.ppc_arch = constants.DEFAULT_PPC_ARCH
 
     build_image_path, dockerfile = _generate_dockerfile_name(args.build_types, args.cuda_versions, args.ppc_arch)
 
@@ -275,5 +275,5 @@ def build_with_container_tool(args, arg_strings):
         for conda_env_file in glob.glob(os.path.join(args.output_folder, "*.yaml")):
             utils.replace_conda_env_channels(conda_env_file,
                                              os.path.abspath(os.path.join(_home_path(args.container_tool),
-                                                                          utils.DEFAULT_OUTPUT_FOLDER)),
+                                                                          constants.DEFAULT_OUTPUT_FOLDER)),
                                                  os.path.abspath(args.output_folder))

--- a/open_ce/get_graph.py
+++ b/open_ce/get_graph.py
@@ -20,7 +20,7 @@ import os
 
 from open_ce.inputs import Argument, ENV_BUILD_ARGS
 from open_ce import graph
-from open_ce import utils
+from open_ce import constants
 from open_ce.errors import log
 
 COMMAND = "graph"
@@ -39,7 +39,7 @@ def export_graph(args):
 
     build_tree = construct_build_tree(args)
     os.makedirs(args.output_folder, exist_ok=True)
-    graph_output = os.path.join(args.output_folder, utils.DEFAULT_GRAPH_FILE)
+    graph_output = os.path.join(args.output_folder, constants.DEFAULT_GRAPH_FILE)
     graph.export_image(build_tree._tree, graph_output, args.width, args.height) # pylint: disable=protected-access
     log.info("Build graph successfully output to: %s", graph_output)
 

--- a/open_ce/get_licenses.py
+++ b/open_ce/get_licenses.py
@@ -32,9 +32,9 @@ from collections import defaultdict
 import requests
 from jinja2 import Environment, FileSystemLoader
 
-from open_ce import utils
+from open_ce import utils, constants
 from open_ce.errors import OpenCEError, Error, show_warning, log
-from open_ce.inputs import Argument, parse_arg_list
+from open_ce.inputs import Argument
 import open_ce.yaml_utils
 
 COMMAND = 'licenses'
@@ -149,7 +149,7 @@ class LicenseGenerator():
         if info in self._licenses:
             return None
 
-        source_folder = os.path.join(utils.TMP_LICENSE_DIR,
+        source_folder = os.path.join(constants.TMP_LICENSE_DIR,
                                      info.name + "-" + str(info.version))
         if not os.path.exists(source_folder):
             os.makedirs(source_folder)
@@ -193,7 +193,7 @@ class LicenseGenerator():
         if not os.path.exists(output_folder):
             os.makedirs(output_folder)
 
-        licenses_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+        licenses_file = os.path.join(output_folder, constants.DEFAULT_LICENSES_FILE)
 
         with open(licenses_file, 'w', encoding='utf8') as file_stream:
             file_stream.write(result)
@@ -260,7 +260,7 @@ class LicenseGenerator():
         with open(os.path.join(package_info_dir, "about.json"), encoding='utf8') as file_stream:
             about_data = open_ce.yaml_utils.load(file_stream)
 
-        open_ce_info = os.path.join(package_info_dir, "recipe", utils.OPEN_CE_INFO_FILE)
+        open_ce_info = os.path.join(package_info_dir, "recipe", constants.OPEN_CE_INFO_FILE)
         info_file_packages = _get_info_file_packages(open_ce_info)
 
         copyright_strings, license_files = _get_copyrights_from_conda_package(meta_data["extracted_package_dir"])
@@ -332,7 +332,7 @@ def _get_source_from_conda_package(pkg_dir):
     """
     #pylint: disable=import-outside-toplevel
     import conda_build.source
-    source_folder = os.path.join(utils.TMP_LICENSE_DIR, os.path.basename(pkg_dir))
+    source_folder = os.path.join(constants.TMP_LICENSE_DIR, os.path.basename(pkg_dir))
     if not os.path.exists(source_folder):
         os.makedirs(source_folder)
 
@@ -539,7 +539,7 @@ def get_licenses(args):
     gen = LicenseGenerator()
 
     if not args.licenses_file:
-        for conda_env_file in parse_arg_list(args.conda_env_files):
+        for conda_env_file in utils.parse_arg_list(args.conda_env_files):
             gen.add_licenses(conda_env_file)
 
         gen.write_licenses_file(args.output_folder)
@@ -547,10 +547,10 @@ def get_licenses(args):
         gen.import_licenses_file(args.licenses_file)
 
     if args.template_files:
-        for template_file in parse_arg_list(args.template_files):
+        for template_file in utils.parse_arg_list(args.template_files):
             gen.gen_file_from_template(template_file, args.output_folder)
 
-    if os.path.exists(utils.TMP_LICENSE_DIR):
-        shutil.rmtree(utils.TMP_LICENSE_DIR)
+    if os.path.exists(constants.TMP_LICENSE_DIR):
+        shutil.rmtree(constants.TMP_LICENSE_DIR)
 
 ENTRY_FUNCTION = get_licenses

--- a/open_ce/images/builder/Dockerfile-p10
+++ b/open_ce/images/builder/Dockerfile-p10
@@ -12,7 +12,7 @@ ENV BUILD_USER=builder
 ARG BUILD_ID=1084
 
 RUN export ARCH="$(uname -m)" && \
-    yum repolist && yum install -y rsync openssh-clients diffutils procps git-lfs gcc-toolset-11 glibc-devel file && \
+    yum repolist && yum install -y rsync openssh-clients diffutils procps git-lfs gcc-toolset-11 glibc-devel file libtirpc-devel && \
     # Create CICD Group
     groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder

--- a/open_ce/inputs.py
+++ b/open_ce/inputs.py
@@ -23,6 +23,7 @@ from enum import Enum, unique
 from open_ce import utils
 from open_ce.errors import OpenCEError, Error, show_warning, log
 from open_ce import __version__ as open_ce_version
+from open_ce import opence_globals, constants
 
 class OpenCEFormatter(argparse.ArgumentDefaultsHelpFormatter):
     """
@@ -49,7 +50,7 @@ class Argument(Enum):
     OUTPUT_FOLDER = (lambda parser: parser.add_argument(
                                         '--output_folder',
                                         type=str,
-                                        default=utils.DEFAULT_OUTPUT_FOLDER,
+                                        default=constants.DEFAULT_OUTPUT_FOLDER,
                                         help='Path where built conda packages will be saved.'))
 
     CHANNELS = (lambda parser: parser.add_argument(
@@ -93,26 +94,26 @@ https://github.com/open-ce/open-ce/blob/main/doc/README.yaml.md"""))
     PYTHON_VERSIONS = (lambda parser: parser.add_argument(
                                         '--python_versions',
                                         type=str,
-                                        default=utils.DEFAULT_PYTHON_VERS,
+                                        default=constants.DEFAULT_PYTHON_VERS,
                                         help='Comma delimited list of python versions to build for '
                                              ', such as "3.8" or "3.9" or "3.10".'))
 
     BUILD_TYPES = (lambda parser: parser.add_argument(
                                         '--build_types',
                                         type=str,
-                                        default=utils.DEFAULT_BUILD_TYPES,
+                                        default=constants.DEFAULT_BUILD_TYPES,
                                         help='Comma delimited list of build types, such as "cpu" or "cuda".'))
 
     MPI_TYPES = (lambda parser: parser.add_argument(
                                         '--mpi_types',
                                         type=str,
-                                        default=utils.DEFAULT_MPI_TYPES,
+                                        default=constants.DEFAULT_MPI_TYPES,
                                         help='Comma delimited list of mpi types, such as "openmpi" or "system".'))
 
     CUDA_VERSIONS = (lambda parser: parser.add_argument(
                                         '--cuda_versions',
                                         type=str,
-                                        default=utils.DEFAULT_CUDA_VERS,
+                                        default=constants.DEFAULT_CUDA_VERS,
                                         help='CUDA version to build for '
                                              ', such as "11.2" or "11.4".'))
 
@@ -149,7 +150,7 @@ https://github.com/open-ce/open-ce/blob/main/doc/README.yaml.md"""))
     PPC_ARCH = (lambda parser: parser.add_argument(
                                         '--ppc_arch',
                                         type=str,
-                                        default=utils.DEFAULT_PPC_ARCH,
+                                        default=constants.DEFAULT_PPC_ARCH,
                                         help="""R|Power Architecture to build for. Values: p9 or p10.
 p9: Libraries can be used on Power8, Power9 and Power 10,
     but do not use MMA acceleration.
@@ -160,13 +161,13 @@ p10: Libraries can be used on Power9 and Power10, and use
     LOCAL_CONDA_CHANNEL = (lambda parser: parser.add_argument(
                                         '--local_conda_channel',
                                         type=str,
-                                        default=utils.DEFAULT_OUTPUT_FOLDER,
+                                        default=constants.DEFAULT_OUTPUT_FOLDER,
                                         help='Path where built conda packages are present.'))
 
     TEST_WORKING_DIRECTORY = (lambda parser: parser.add_argument(
                                         '--test_working_dir',
                                         type=str,
-                                        default=utils.DEFAULT_TEST_WORKING_DIRECTORY,
+                                        default=constants.DEFAULT_TEST_WORKING_DIRECTORY,
                                         help="Directory where tests will be executed."))
 
     RECIPE_CONFIG_FILE = (lambda parser: parser.add_argument(
@@ -212,7 +213,7 @@ path of \"recipe\"."""))
     GIT_LOCATION = (lambda parser: parser.add_argument(
                                         '--git_location',
                                         type=str,
-                                        default=utils.DEFAULT_GIT_LOCATION,
+                                        default=constants.DEFAULT_GIT_LOCATION,
                                         help='The default location to clone git repositories from.'))
 
     GIT_TAG_FOR_ENV = (lambda parser: parser.add_argument(
@@ -257,7 +258,7 @@ path of \"recipe\"."""))
     CONTAINER_TOOL = (lambda parser: parser.add_argument(
                                         '--container_tool',
                                         type=str,
-                                        default=utils.DEFAULT_CONTAINER_TOOL,
+                                        default=constants.DEFAULT_CONTAINER_TOOL,
                                         help="Container tool to be used. Default is taken from the "
                                              " system, podman has preference over docker. "))
 
@@ -287,7 +288,7 @@ path of \"recipe\"."""))
     CONDA_PKG_FORMAT = (lambda parser: parser.add_argument(
                                         '--conda_pkg_format',
                                         type=str,
-                                        default=utils.DEFAULT_PKG_FORMAT,
+                                        default=constants.DEFAULT_PKG_FORMAT,
                                         help='Conda package format to be used, such as "tarball" or "conda".'))
     WIDTH = (lambda parser: parser.add_argument(
                                      '--width',
@@ -368,7 +369,7 @@ def _create_env_config_paths(args):
                     file_name = file_name + extension
 
                 new_url = f"https://raw.githubusercontent.com/{organization}/" \
-                          f"{utils.DEFAULT_ENVS_REPO}/{branch}/envs/{file_name}"
+                          f"{constants.DEFAULT_ENVS_REPO}/{branch}/envs/{file_name}"
 
                 log.info("Unable to find '%s' locally. Attempting to use '%s'.", config_file, new_url)
                 args.env_config_file[index] = new_url
@@ -379,14 +380,14 @@ def _check_ppc_arch(args):
     needed environment variables for GCC_11_HOME
     '''
     if "ppc_arch" in vars(args).keys() and args.ppc_arch:
-        utils.PPC_ARCH_VARIANT = args.ppc_arch
+        opence_globals.PPC_ARCH_VARIANT = args.ppc_arch
         if args.ppc_arch == "p10":
             if "GCC_11_HOME" not in os.environ:
-                os.environ["GCC_11_HOME"] = utils.DEFAULT_GCC_11_HOME_DIR
+                os.environ["GCC_11_HOME"] = constants.DEFAULT_GCC_11_HOME_DIR
                 PATH = os.environ["PATH"]
                 os.environ["PATH"] = f"{os.path.join(os.environ['GCC_11_HOME'], 'bin')}:{PATH}"
                 print("Path variable set to : ", os.environ["PATH"])
-            if not os.path.exists(utils.DEFAULT_GCC_11_HOME_DIR):
+            if not os.path.exists(constants.DEFAULT_GCC_11_HOME_DIR):
                 raise OpenCEError(Error.GCC11_COMPILER_NOT_FOUND)
 
 
@@ -407,20 +408,14 @@ def parse_args(parser, arg_strings=None):
         if args.conda_build_configs is None:
             if "env_config_file" in vars(args).keys() and args.env_config_file:
                 args.conda_build_configs = os.path.join(os.path.dirname(args.env_config_file[0]),
-                                                       utils.CONDA_BUILD_CONFIG_FILE)
+                                                       constants.CONDA_BUILD_CONFIG_FILE)
             else:
-                args.conda_build_configs = utils.DEFAULT_CONDA_BUILD_CONFIG
+                args.conda_build_configs = constants.DEFAULT_CONDA_BUILD_CONFIG
 
-        configs = utils.get_conda_build_configs(parse_arg_list(args.conda_build_configs))
+        configs = utils.get_conda_build_configs(utils.parse_arg_list(args.conda_build_configs))
         args.conda_build_configs = configs
 
         if not configs:
-            show_warning(Error.CONDA_BUILD_CONFIG_NOT_FOUND, utils.CONDA_BUILD_CONFIG_FILE)
+            show_warning(Error.CONDA_BUILD_CONFIG_NOT_FOUND, constants.CONDA_BUILD_CONFIG_FILE)
 
     return args
-
-def parse_arg_list(arg_list):
-    ''' Turn a comma delimited string into a python list'''
-    if isinstance(arg_list, list):
-        return arg_list
-    return arg_list.split(",") if not arg_list is None else []

--- a/open_ce/opence_globals.py
+++ b/open_ce/opence_globals.py
@@ -1,0 +1,22 @@
+"""
+# *****************************************************************
+# (C) Copyright IBM Corp. 2022. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *****************************************************************
+"""
+
+from open_ce.constants import DEFAULT_PPC_ARCH
+
+global PPC_ARCH_VARIANT        # pylint: disable=global-at-module-level
+PPC_ARCH_VARIANT = DEFAULT_PPC_ARCH

--- a/open_ce/test_feedstock.py
+++ b/open_ce/test_feedstock.py
@@ -23,9 +23,8 @@ from enum import Enum, unique, auto
 import time
 from junit_xml import TestSuite, TestCase, to_xml_report_string
 
-from open_ce import utils
+from open_ce import utils, constants
 from open_ce import conda_env_file_generator
-from open_ce import inputs
 from open_ce.inputs import Argument
 from open_ce.errors import OpenCEError, Error, log
 
@@ -199,7 +198,7 @@ def load_test_file(test_file, variants):
 
     return test_file_data
 
-def gen_test_commands(test_file=utils.DEFAULT_TEST_CONFIG_FILE, variants=None, working_dir=os.getcwd()):
+def gen_test_commands(test_file=constants.DEFAULT_TEST_CONFIG_FILE, variants=None, working_dir=os.getcwd()):
     """
     Generate a list of test commands from the provided test file.
 
@@ -211,7 +210,7 @@ def gen_test_commands(test_file=utils.DEFAULT_TEST_CONFIG_FILE, variants=None, w
         return []
 
     time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-    conda_env = utils.CONDA_ENV_FILENAME_PREFIX + time_stamp
+    conda_env = constants.CONDA_ENV_FILENAME_PREFIX + time_stamp
 
     test_commands = []
 
@@ -248,7 +247,7 @@ def run_test_commands(conda_env_file, test_commands):
     return [x.run(conda_env_file) for x in test_commands]
 
 def test_feedstock(conda_env_file, test_labels=None,
-                   test_working_dir=utils.DEFAULT_TEST_WORKING_DIRECTORY, working_directory=None):
+                   test_working_dir=constants.DEFAULT_TEST_WORKING_DIRECTORY, working_directory=None):
     """
     Test a particular feedstock, provided by the working_directory argument.
     """
@@ -263,7 +262,7 @@ def test_feedstock(conda_env_file, test_labels=None,
         variant_dict = utils.variant_string_to_dict(var_string)
     else:
         variant_dict = {}
-    for test_label in inputs.parse_arg_list(test_labels):
+    for test_label in utils.parse_arg_list(test_labels):
         variant_dict[test_label] = True
     test_commands = gen_test_commands(working_dir=test_working_dir, variants=variant_dict)
     test_results = run_test_commands(conda_env_file, test_commands)
@@ -283,7 +282,7 @@ def process_test_results(test_results, output_folder="./", test_labels=None):
         label_string = f"with labels: {str(test_labels)}"
     test_suites = [TestSuite(f"Open-CE tests for {feedstock} {label_string}", test_results[feedstock])
                         for feedstock in test_results]
-    with open(os.path.join(output_folder, utils.DEFAULT_TEST_RESULT_FILE), 'w', encoding='utf8') as outfile:
+    with open(os.path.join(output_folder, constants.DEFAULT_TEST_RESULT_FILE), 'w', encoding='utf8') as outfile:
         outfile.write(to_xml_report_string(test_suites))
     failed_tests = [x for key in test_results for x in test_results[key] if x.is_failure()]
     if failed_tests:
@@ -300,7 +299,7 @@ def test_feedstock_entry(args):
     else:
         feedstock = os.path.basename(os.getcwd())
     test_results = {feedstock: []}
-    for conda_env_file in inputs.parse_arg_list(args.conda_env_files):
+    for conda_env_file in utils.parse_arg_list(args.conda_env_files):
         test_results[feedstock] += test_feedstock(conda_env_file,
                                        args.test_labels,
                                        args.test_working_dir,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIRED_PACKAGES = [
     "jinja2",
     "networkx",
     "junit-xml",
-    #"matplotlib", broken on ppc
+    "matplotlib",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIRED_PACKAGES = [
     "jinja2",
     "networkx",
     "junit-xml",
-    "matplotlib",
+    "matplotlib==3.5",
 ]
 
 setup(

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -31,6 +31,7 @@ spec.loader.exec_module(opence)
 import helpers
 import open_ce.build_env as build_env
 import open_ce.utils as utils
+import open_ce.constants as constants
 from open_ce.errors import OpenCEError
 from build_tree_test import TestBuildTree
 import open_ce.test_feedstock as test_feedstock
@@ -292,16 +293,16 @@ def test_build_env(mocker, caplog):
     opence._main(["build", build_env.COMMAND, env_file])
     validate_and_remove_conda_env_files()
 
-def validate_and_remove_conda_env_files(py_versions=utils.DEFAULT_PYTHON_VERS,
-                                        build_types=utils.DEFAULT_BUILD_TYPES,
-                                        mpi_types=utils.DEFAULT_MPI_TYPES,
-                                        cuda_versions=utils.DEFAULT_CUDA_VERS,
+def validate_and_remove_conda_env_files(py_versions=constants.DEFAULT_PYTHON_VERS,
+                                        build_types=constants.DEFAULT_BUILD_TYPES,
+                                        mpi_types=constants.DEFAULT_MPI_TYPES,
+                                        cuda_versions=constants.DEFAULT_CUDA_VERS,
                                         channels=None):
     # Check if conda env files are created for given python versions and build variants
     variants = utils.make_variants(py_versions, build_types, mpi_types, cuda_versions)
     for variant in variants:
-        conda_env_file = os.path.join(os.getcwd(), utils.DEFAULT_OUTPUT_FOLDER,
-                                     "{}{}.yaml".format(utils.CONDA_ENV_FILENAME_PREFIX,
+        conda_env_file = os.path.join(os.getcwd(), constants.DEFAULT_OUTPUT_FOLDER,
+                                     "{}{}.yaml".format(constants.CONDA_ENV_FILENAME_PREFIX,
                                      utils.variant_string(variant.get('python'), variant.get('build_type'), variant.get('mpi_type'), variant.get('cudatoolkit'))))
         assert os.path.exists(conda_env_file)
         if channels:
@@ -464,7 +465,7 @@ def test_run_tests(mocker):
     Test that the _run_tests function works properly.
     '''
     dirTracker = helpers.DirTracker()
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu,cuda", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu,cuda", "openmpi", "10.2")
     mock_test_commands = [test_feedstock.TestCommand("Test1",
                                                       conda_env="test-conda-env2.yaml",
                                                       bash_command="echo Test1"),

--- a/tests/build_feedstock_test.py
+++ b/tests/build_feedstock_test.py
@@ -28,7 +28,7 @@ opence = module_from_spec(spec)
 spec.loader.exec_module(opence)
 
 import helpers
-import open_ce.utils as utils
+import open_ce.constants as constants
 from open_ce.errors import OpenCEError
 import open_ce.build_feedstock as build_feedstock
 
@@ -46,7 +46,7 @@ def test_build_feedstock_default(mocker):
     )
     expect_recipe = os.path.join(os.getcwd(),'recipe')
     expect_config = {'variant_config_files' : [],
-                'output_folder' : utils.DEFAULT_OUTPUT_FOLDER}
+                'output_folder' : constants.DEFAULT_OUTPUT_FOLDER}
     mocker.patch(
         'conda_build.api.build',
         side_effect=(lambda x, **kwargs: helpers.validate_conda_build_args(x, expect_recipe=expect_recipe, expect_config=expect_config, **kwargs))
@@ -219,7 +219,7 @@ def test_build_feedstock_extra_args(mocker):
     )
 
     expect_config = { 'channel_urls' : ['/test/test_recipe/condabuild', 'test_channel', 'test_channel_2', 'test_channel_from_config']}
-    expect_variants = {'python': utils.DEFAULT_PYTHON_VERS, 'build_type': 'cpu', 'mpi_type': 'openmpi'}
+    expect_variants = {'python': constants.DEFAULT_PYTHON_VERS, 'build_type': 'cpu', 'mpi_type': 'openmpi'}
     reject_recipe = os.path.join(os.getcwd(),'test_recipe_extra')
     mocker.patch(
         'conda_build.api.build',
@@ -237,7 +237,7 @@ def test_build_feedstock_extra_args(mocker):
                  "--channels", "test_channel",
                  "--channels", "test_channel_2",
                  "--recipes", "my_project,my_variant",
-                 "--python_versions", utils.DEFAULT_PYTHON_VERS,
+                 "--python_versions", constants.DEFAULT_PYTHON_VERS,
                  "--build_types", "cpu",
                  "--mpi_types", "openmpi",
                  "--cuda_versions", "10.2"]

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -30,7 +30,7 @@ spec.loader.exec_module(opence)
 import helpers
 import open_ce.build_image as build_image
 from open_ce.errors import OpenCEError, Error
-from open_ce import utils
+from open_ce import utils, constants
 
 TEST_CONDA_ENV_FILE=os.path.join(test_dir,"test-conda-env.yaml")
 TEST_LOCAL_CONDA_CHANNEL_DIR=os.path.join(test_dir, "testcondabuild")
@@ -45,7 +45,7 @@ def test_build_image_positive_case(mocker):
     mocker.patch('open_ce.utils.get_open_ce_version', return_value=open_ce_version)
 
     intended_image_name = build_image.REPO_NAME + ":" + open_ce_version + TEST_IMAGE_NAME_SUFFIX
-    container_tool = utils.DEFAULT_CONTAINER_TOOL
+    container_tool = constants.DEFAULT_CONTAINER_TOOL
 
     mocker.patch(
         'os.system',
@@ -84,7 +84,7 @@ def test_local_conda_channel_with_absolute_path(mocker):
 
     open_ce_version = utils.get_open_ce_version(TEST_CONDA_ENV_FILE)
     intended_image_name = build_image.REPO_NAME + ":" + open_ce_version + TEST_IMAGE_NAME_SUFFIX
-    container_tool = utils.DEFAULT_CONTAINER_TOOL
+    container_tool = constants.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
         return_value=0,
@@ -116,7 +116,7 @@ def test_channel_update_in_conda_env(mocker):
 
     open_ce_version = utils.get_open_ce_version(TEST_CONDA_ENV_FILE)
     intended_image_name = build_image.REPO_NAME + ":" + open_ce_version + TEST_IMAGE_NAME_SUFFIX 
-    container_tool = utils.DEFAULT_CONTAINER_TOOL
+    container_tool = constants.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
         return_value=0,
@@ -159,7 +159,7 @@ def test_modified_file_removed(mocker):
     '''
     open_ce_version = utils.get_open_ce_version(TEST_CONDA_ENV_FILE)
     intended_image_name = build_image.REPO_NAME + ":" + open_ce_version + TEST_IMAGE_NAME_SUFFIX
-    container_tool = utils.DEFAULT_CONTAINER_TOOL
+    container_tool = constants.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
         return_value=0,
@@ -196,7 +196,7 @@ def test_build_image_name(mocker):
     Tests that runtime image gets its name based on the env file passed.
     '''
     intended_image_name = build_image.REPO_NAME + ":" + "open-ce-v1.2.0" + TEST_IMAGE_NAME_SUFFIX 
-    container_tool = utils.DEFAULT_CONTAINER_TOOL
+    container_tool = constants.DEFAULT_CONTAINER_TOOL
 
     mocker.patch('os.system', return_value=0)
     os.mkdir(os.path.join(TEST_LOCAL_CONDA_CHANNEL_DIR, build_image.TEMP_FILES))

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -24,9 +24,11 @@ test_dir = pathlib.Path(__file__).parent.absolute()
 from open_ce import graph
 import open_ce.build_tree as build_tree
 import open_ce.utils as utils
+import open_ce.constants as constants
 import open_ce.env_config as env_config
 from open_ce.errors import OpenCEError, Error
 import helpers
+from open_ce import opence_globals
 
 def conda_search_result():
     output = '''
@@ -90,10 +92,10 @@ class TestBuildTree(build_tree.BuildTree):
                  cuda_versions,
                  repository_folder="./",
                  channels=None,
-                 git_location=utils.DEFAULT_GIT_LOCATION,
-                 git_tag_for_env=utils.DEFAULT_GIT_TAG,
+                 git_location=constants.DEFAULT_GIT_LOCATION,
+                 git_tag_for_env=constants.DEFAULT_GIT_TAG,
                  git_up_to_date = False,
-                 conda_build_config=utils.DEFAULT_CONDA_BUILD_CONFIG):
+                 conda_build_config=constants.DEFAULT_CONDA_BUILD_CONFIG):
         self._env_config_files = env_config_files
         self._repository_folder = repository_folder
         self._channels = channels if channels else []
@@ -134,7 +136,7 @@ def test_create_commands(mocker):
                                                                            "/test/starting_dir"])) # And then changed back to the starting directory.
     )
 
-    build_commands = [x.build_command for x in build_tree._create_commands("/test/my_repo", "True", "my_recipe_path", None, "main", {'python' : utils.DEFAULT_PYTHON_VERS, 'build_type' : 'cuda', 'mpi_type' : 'openmpi', 'cudatoolkit' : '10.2'}, []).nodes()]
+    build_commands = [x.build_command for x in build_tree._create_commands("/test/my_repo", "True", "my_recipe_path", None, "main", {'python' : constants.DEFAULT_PYTHON_VERS, 'build_type' : 'cuda', 'mpi_type' : 'openmpi', 'cudatoolkit' : '10.2'}, []).nodes()]
     assert build_commands[0].packages == ['horovod']
     assert build_commands[0].recipe_path == "my_recipe_path"
     for dep in {'build_req1', 'build_req2            1.2'}:
@@ -182,9 +184,9 @@ def test_clone_repo(mocker):
     '''
     Simple positive test for `_clone_repo`.
     '''
-    git_location = utils.DEFAULT_GIT_LOCATION
+    git_location = constants.DEFAULT_GIT_LOCATION
 
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2", git_tag_for_env="main")
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2", git_tag_for_env="main")
 
     dir_tracker= helpers.DirTracker()
     mocker.patch(
@@ -210,7 +212,7 @@ def test_get_repo_git_tag_options(mocker, caplog):
     Test for `_get_repo` that verifies `git_tag` and `git_tag_for_env` priorities.
     '''
     env_file1 = os.path.join(test_dir, 'test-env1.yaml')
-    mock_build_tree = TestBuildTree([env_file1], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([env_file1], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
 
     dir_tracker= helpers.DirTracker()
     mocker.patch(
@@ -227,7 +229,7 @@ def test_get_repo_git_tag_options(mocker, caplog):
         side_effect=(lambda x: helpers.validate_cli(x, possible_expect=["git clone", "git checkout"]))
     )
 
-    possible_variants = utils.make_variants(utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    possible_variants = utils.make_variants(constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     for variant in possible_variants:
 
         # test-env1.yaml has defined "git_tag" and "git_tag_for_env".
@@ -269,7 +271,7 @@ def test_get_repo_with_patches(mocker, caplog):
     Test for `_get_repo` that verifies `patches` field
     '''
     env_file = os.path.join(test_dir, 'test-env3.yaml')
-    mock_build_tree = TestBuildTree([env_file], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([env_file], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
 
     dir_tracker= helpers.DirTracker()
     mocker.patch(
@@ -287,7 +289,7 @@ def test_get_repo_with_patches(mocker, caplog):
         side_effect=(lambda x: helpers.validate_cli(x, expect=["git apply"], ignore=["git clone", "git checkout"]))
     )
 
-    possible_variants = utils.make_variants(utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    possible_variants = utils.make_variants(constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     for variant in possible_variants:
         # test-env3.yaml has specified "patches".
         env_config_data_list = env_config.load_env_config_files([env_file], [variant])
@@ -305,7 +307,7 @@ def test_get_repo_for_nonexisting_patch(mocker):
     Test for `_get_repo` that verifies exception is thrown when patch application fails
     '''
     env_file = os.path.join(test_dir, 'test-env3.yaml')
-    mock_build_tree = TestBuildTree([env_file], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([env_file], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
 
     dir_tracker= helpers.DirTracker()
     mocker.patch(
@@ -325,7 +327,7 @@ def test_get_repo_for_nonexisting_patch(mocker):
         return_value=None
     )
 
-    possible_variants = utils.make_variants(utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    possible_variants = utils.make_variants(constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     for variant in possible_variants:
         # test-env3.yaml has defined "patches".
         env_config_data_list = env_config.load_env_config_files([env_file], [variant])
@@ -359,7 +361,7 @@ def test_clone_repo_failure(mocker):
     '''
     Simple negative test for `_clone_repo`.
     '''
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
 
     mocker.patch(
         'os.system',
@@ -375,7 +377,7 @@ def test_empty_git_tag_remote_feedstock(mocker):
     Test that the error is thrown if `git_tag` is not present for remote feedstocks
     '''
     env_file1 = os.path.join(test_dir, 'test-env4.yaml')
-    mock_build_tree = TestBuildTree([env_file1], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([env_file1], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
 
     dir_tracker= helpers.DirTracker()
     mocker.patch(
@@ -392,7 +394,7 @@ def test_empty_git_tag_remote_feedstock(mocker):
         side_effect=(lambda x: helpers.validate_cli(x, possible_expect=["git clone", "git checkout"]))
     )
 
-    possible_variants = utils.make_variants(utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    possible_variants = utils.make_variants(constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     for variant in possible_variants:
 
         # test-env4.yaml has one remote feedstock without "git_tag" and another one 
@@ -415,7 +417,7 @@ def test_check_runtime_package_field():
     '''
     env_file = os.path.join(test_dir, 'test-env3.yaml')
 
-    possible_variants = utils.make_variants(utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    possible_variants = utils.make_variants(constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     for variant in possible_variants:
 
         # test-env3.yaml has defined "runtime_package" for "package222".
@@ -431,8 +433,8 @@ def test_check_ppc_arch_filter():
     Test if `ppc_arch` filter works and envs are loaded conditionally
     '''
     env_file = os.path.join(test_dir, 'test-env2.yaml')
-    utils.PPC_ARCH_VARIANT = "p10"
-    possible_variants = utils.make_variants(utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    opence_globals.PPC_ARCH_VARIANT = "p10"
+    possible_variants = utils.make_variants(constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     for variant in possible_variants:
 
         # test-env2.yaml imports test-env5.yaml only if ppc_arch is p10 and test-env5.yaml
@@ -453,7 +455,7 @@ def test_check_recipe_path_package_field():
     '''
     env_file = os.path.join(test_dir, 'test-env1.yaml')
 
-    possible_variants = utils.make_variants(utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    possible_variants = utils.make_variants(constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     for variant in possible_variants:
 
         # test-env1.yaml has defined "recipe_path" as "package11_recipe_path" for "package11".
@@ -510,7 +512,7 @@ def test_get_dependency_names():
     '''
     Tests that the dependency names can be retrieved for each item in a BuildTree
     '''
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     mock_build_tree._tree = sample_build_commands()
 
     output = ""
@@ -525,7 +527,7 @@ def test_build_tree_len():
     '''
     Tests that the __len__ function works for BuildTree
     '''
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     mock_build_tree._tree = sample_build_commands()
 
     assert len(mock_build_tree) == 3
@@ -564,7 +566,7 @@ def test_build_tree_cycle_fail():
     cycle_build_commands.add_edge(node2, node1)
     cycle_build_commands.add_edge(node3, node2)
 
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     mock_build_tree._tree = sample_build_commands()
 
     mock_build_tree._detect_cycle() #Make sure there isn't a false positive.
@@ -657,7 +659,7 @@ def test_get_installable_package_with_no_duplicates():
     assert Counter(packages) == Counter(expected_packages)
 
 def test_get_build_copmmand_dependencies():
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     mock_build_tree._initial_nodes = []
     mock_build_tree._tree = sample_build_commands()
     results = [mock_build_tree.build_command_dependencies(node) for node in mock_build_tree.BuildNodes()]
@@ -682,7 +684,7 @@ def test_dag_cleanup():
     '''
     Test that external packages are removed during cleanup.
     '''
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2")
     mock_build_tree._tree = sample_build_commands()
 
     external_node = build_tree.DependencyNode(packages=["external_package"])
@@ -703,7 +705,7 @@ def test_search_channels(mocker):
     '''
     Test that recipe specific channels are used for remote dependency discovery.
     '''
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2", channels=["defaults"])
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2", channels=["defaults"])
     dep_graph = sample_build_commands()
 
     external_node = build_tree.DependencyNode(packages=["external_package"])
@@ -770,7 +772,7 @@ def test_search_package_priority(mocker):
     '''
     Test remote package priority.
     '''
-    mock_build_tree = TestBuildTree([], utils.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2", channels=["defaults"])
+    mock_build_tree = TestBuildTree([], constants.DEFAULT_PYTHON_VERS, "cpu", "openmpi", "10.2", channels=["defaults"])
     dep_graph = sample_build_commands()
 
     external_node = build_tree.DependencyNode(packages=["external_package"])

--- a/tests/conda_env_file_generator_test.py
+++ b/tests/conda_env_file_generator_test.py
@@ -33,7 +33,7 @@ spec.loader.exec_module(opence)
 import open_ce.build_env as build_env
 import open_ce.build_tree as build_tree
 import open_ce.conda_env_file_generator as conda_env_file_generator
-import open_ce.utils as utils
+import open_ce.constants as constants
 
 external_deps = ["external_pac1    1.2", "external_pack2", "external_pack3=1.2.3"]
 
@@ -117,7 +117,7 @@ def test_create_channels():
 
 def test_get_variant_string(mocker):
     var_str = "py3.8-cuda-openmpi-10.2"
-    test_env_file = "#" + utils.OPEN_CE_VARIANT + ":" + var_str + "\nsomething else"
+    test_env_file = "#" + constants.OPEN_CE_VARIANT + ":" + var_str + "\nsomething else"
     mocker.patch('builtins.open', mocker.mock_open(read_data=test_env_file))
 
     assert conda_env_file_generator.get_variant_string("some_file.yaml") == var_str
@@ -131,7 +131,7 @@ def test_get_variant_string_no_string(mocker):
 def test_variant_specific_env_files():
     tmp_test = tempfile.TemporaryDirectory()
     base_arg_strings = ["build", build_env.COMMAND, "--skip_build",
-                   "--python_versions", utils.DEFAULT_PYTHON_VERS,
+                   "--python_versions", constants.DEFAULT_PYTHON_VERS,
                    "--cuda_versions", "11.4",
                    "--repository_folder", os.path.join(tmp_test.name, "repos"),
                    "--output_folder", os.path.join(tmp_test.name, "output"),

--- a/tests/container_build_test.py
+++ b/tests/container_build_test.py
@@ -23,7 +23,7 @@ test_dir = pathlib.Path(__file__).parent.absolute()
 
 import helpers
 import open_ce.container_build as container_build
-import open_ce.utils as utils
+import open_ce.constants as constants
 from open_ce.errors import OpenCEError
 
 def test_build_image(mocker):
@@ -126,8 +126,8 @@ def make_args(command="build",
               build_types="cuda",
               cuda_versions="11.2",
               container_build_args="",
-              container_tool=utils.DEFAULT_CONTAINER_TOOL,
-              ppc_arch=utils.DEFAULT_PPC_ARCH,
+              container_tool=constants.DEFAULT_CONTAINER_TOOL,
+              ppc_arch=constants.DEFAULT_PPC_ARCH,
               **kwargs):
     return Namespace(command = command,
                      sub_command = sub_command,

--- a/tests/get_graph_test.py
+++ b/tests/get_graph_test.py
@@ -27,7 +27,7 @@ opence = module_from_spec(spec)
 spec.loader.exec_module(opence)
 
 import open_ce.get_graph as get_graph
-import open_ce.utils as utils
+import open_ce.constants as constants
 
 def test_get_graph(caplog):
     '''
@@ -44,7 +44,7 @@ def test_get_graph(caplog):
 
     assert "Build graph successfully output" in caplog.text
 
-    output_file = os.path.join(output_folder, utils.DEFAULT_GRAPH_FILE)
+    output_file = os.path.join(output_folder, constants.DEFAULT_GRAPH_FILE)
     assert os.path.exists(output_file)
 
     tmp_test.cleanup()

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -29,7 +29,8 @@ opence = module_from_spec(spec)
 spec.loader.exec_module(opence)
 
 import open_ce.get_licenses as get_licenses
-import open_ce.utils as utils
+import open_ce.constants as constants
+
 from open_ce.errors import OpenCEError
 
 def test_get_licenses(mocker):
@@ -43,7 +44,7 @@ def test_get_licenses(mocker):
     template_file = "tests/open-ce-licenses.template"
     opence._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env3.yaml", "--output_folder", output_folder, "--template_files", template_file])
 
-    output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+    output_file = os.path.join(output_folder, constants.DEFAULT_LICENSES_FILE)
     assert os.path.exists(output_file)
     with open(output_file, encoding='utf8') as file_stream:
         license_contents = file_stream.read()
@@ -129,7 +130,7 @@ def test_add_licenses_from_info_file(mocker, capfd):
 
     gen.write_licenses_file(output_folder)
 
-    output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+    output_file = os.path.join(output_folder, constants.DEFAULT_LICENSES_FILE)
     assert os.path.exists(output_file)
     with open(output_file, encoding='utf8') as file_stream:
         license_contents = file_stream.read()
@@ -143,7 +144,7 @@ def test_add_licenses_from_info_file(mocker, capfd):
     # Make sure google-test only appears once
     assert license_contents.count("google-test\t1.7.0") == 1
     shutil.rmtree(output_folder)
-    shutil.rmtree(utils.TMP_LICENSE_DIR)
+    shutil.rmtree(constants.TMP_LICENSE_DIR)
 
 def test_no_info_file():
     '''
@@ -155,7 +156,7 @@ def test_no_info_file():
     gen.add_licenses_from_info_files(license_info)
     gen.write_licenses_file(output_folder)
 
-    output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+    output_file = os.path.join(output_folder, constants.DEFAULT_LICENSES_FILE)
     assert os.path.exists(output_file)
     with open(output_file, encoding='utf8') as file_stream:
         license_contents = file_stream.read()

--- a/tests/test_feedstock_test.py
+++ b/tests/test_feedstock_test.py
@@ -30,7 +30,7 @@ opence = module_from_spec(spec)
 spec.loader.exec_module(opence)
 
 import open_ce.test_feedstock as test_feedstock
-import open_ce.utils as utils
+import open_ce.constants as constants
 from open_ce.errors import OpenCEError
 
 orig_load_test_file = test_feedstock.load_test_file
@@ -40,7 +40,7 @@ def mock_load_test_file(x, y):
 def validate_junit(required_test_results,
                    excluded_test_results,
                    expected_test_cases,
-                   junit_file=os.path.join("./", utils.DEFAULT_TEST_RESULT_FILE),
+                   junit_file=os.path.join("./", constants.DEFAULT_TEST_RESULT_FILE),
                    expected_failures=None):
     '''
     Used to validate the contents of a junit file.
@@ -71,13 +71,13 @@ def test_test_feedstock_complete(mocker, caplog):
     mocker.patch('open_ce.test_feedstock.load_test_file', side_effect=(lambda x, y: mock_load_test_file(os.path.join(test_dir, "open-ce-tests1.yaml"), y)))
 
     opence._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml"])
-    assert "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    assert "Running: Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
     assert "Running: Test 1" in caplog.text
     assert not "Running: Test 2" in caplog.text
-    assert "Running: Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
-    validate_junit([[{"name": "Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX},
+    assert "Running: Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    validate_junit([[{"name": "Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX},
                      {"name": "Test 1"},
-                     {"name": "Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX}]],
+                     {"name": "Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX}]],
                    [[{"name": "Test 2"}]],
                    [3])
 
@@ -95,11 +95,11 @@ def test_test_feedstock_failed_tests(mocker, caplog):
     assert "Failed test: Test 1" in caplog.text
     assert "Failed test: Test 3" in caplog.text
     assert not "Failed test: Test 2" in caplog.text
-    validate_junit([[{"name": "Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX},
+    validate_junit([[{"name": "Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX},
                      {"name": "Test 1"},
                      {"name": "Test 2"},
                      {"name": "Test 3"},
-                     {"name": "Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX}]],
+                     {"name": "Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX}]],
                    [[]],
                    [5],
                    expected_failures = [2])
@@ -118,10 +118,10 @@ def test_test_feedstock_working_dir(mocker, caplog):
     opence._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--test_working_dir", working_dir])
     assert os.path.exists(working_dir)
     shutil.rmtree(working_dir)
-    assert "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    assert "Running: Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
     assert "Running: Test 1" in caplog.text
     assert "Running: Test 2" in caplog.text
-    assert "Running: Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    assert "Running: Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
 
 def test_test_feedstock_labels(mocker, caplog):
     '''
@@ -131,50 +131,50 @@ def test_test_feedstock_labels(mocker, caplog):
     mocker.patch('open_ce.test_feedstock.load_test_file', side_effect=(lambda x, y: mock_load_test_file(os.path.join(test_dir, "open-ce-tests3.yaml"), y)))
 
     opence._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml"])
-    assert not "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    assert not "Running: Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
     assert not "Running: Test Long" in caplog.text
     assert not "Running: Test Distributed" in caplog.text
     assert not "Running: Test Long and Distributed" in caplog.text
-    assert not "Running: Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    assert not "Running: Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
     validate_junit([[]],
                    [[]],
                    [0])
     caplog.clear()
     opence._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--test_labels", "long"])
-    assert "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    assert "Running: Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
     assert "Running: Test Long" in caplog.text
     assert not "Running: Test Distributed" in caplog.text
     assert not "Running: Test Long and Distributed" in caplog.text
-    assert "Running: Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
-    validate_junit([[{"name": "Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX},
+    assert "Running: Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    validate_junit([[{"name": "Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX},
                      {"name": "Test Long"},
-                     {"name": "Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX}]],
+                     {"name": "Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX}]],
                    [[{"name": "Test Distributed"},
                      {"name": "Test Long and Distributed"}]],
                    [3])
     caplog.clear()
     opence._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--test_labels", "distributed"])
-    assert "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    assert "Running: Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
     assert not "Running: Test Long" in caplog.text
     assert "Running: Test Distributed" in caplog.text
     assert not "Running: Test Long and Distributed" in caplog.text
-    assert "Running: Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
-    validate_junit([[{"name": "Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX},
+    assert "Running: Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    validate_junit([[{"name": "Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX},
                      {"name": "Test Distributed"},
-                     {"name": "Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX}]],
+                     {"name": "Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX}]],
                    [[{"name": "Test Long"},
                      {"name": "Test Long and Distributed"}]],
                    [3])
     caplog.clear()
     opence._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--test_labels", "long,distributed"])
-    assert "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    assert "Running: Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
     assert "Running: Test Long" in caplog.text
     assert "Running: Test Distributed" in caplog.text
     assert "Running: Test Long and Distributed" in caplog.text
-    assert "Running: Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in caplog.text
-    validate_junit([[{"name": "Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX},
+    assert "Running: Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX in caplog.text
+    validate_junit([[{"name": "Create conda environment " + constants.CONDA_ENV_FILENAME_PREFIX},
                      {"name": "Test Distributed"},
-                     {"name": "Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX},
+                     {"name": "Remove conda environment " + constants.CONDA_ENV_FILENAME_PREFIX},
                      {"name": "Test Long"},
                      {"name": "Test Long and Distributed"}]],
                    [[]],

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -21,7 +21,6 @@ import os
 
 test_dir = pathlib.Path(__file__).parent.absolute()
 
-import open_ce.inputs as inputs
 import open_ce.utils as utils
 from open_ce.errors import OpenCEError
 
@@ -30,7 +29,7 @@ def test_parse_arg_list_list_input():
     Parse arg list should return the input argument if it's already a list.
     '''
     list_input = ["a", "b", "c"]
-    assert list_input == inputs.parse_arg_list(list_input)
+    assert list_input == utils.parse_arg_list(list_input)
 
 def test_parse_arg_list_small_string_input():
     '''
@@ -38,7 +37,7 @@ def test_parse_arg_list_small_string_input():
     '''
     string_input = "a,b,c"
     list_output = ["a", "b", "c"]
-    assert list_output == inputs.parse_arg_list(string_input)
+    assert list_output == utils.parse_arg_list(string_input)
 
 def test_parse_arg_list_large_string_input():
     '''
@@ -46,7 +45,7 @@ def test_parse_arg_list_large_string_input():
     '''
     string_input = "this,is a, big  , test  ,"
     list_output = ["this", "is a", " big  ", " test  ", ""]
-    assert list_output == inputs.parse_arg_list(string_input)
+    assert list_output == utils.parse_arg_list(string_input)
 
 def test_cuda_level_supported(mocker):
     '''

--- a/tests/validate_config_test.py
+++ b/tests/validate_config_test.py
@@ -30,7 +30,7 @@ spec.loader.exec_module(opence)
 
 import open_ce.validate_config as validate_config
 from open_ce.errors import OpenCEError
-import open_ce.utils as utils
+import open_ce.constants as constants
 
 def conda_search_result():
     output = '''
@@ -135,7 +135,7 @@ def test_validate_config(mocker):
     )
 
     env_file = os.path.join(test_dir, 'test-env2.yaml')
-    opence._main(["validate", validate_config.COMMAND, "--conda_build_configs", "./tests/conda_build_config.yaml", env_file, "--python_versions", utils.DEFAULT_PYTHON_VERS, "--build_types", "cuda"])
+    opence._main(["validate", validate_config.COMMAND, "--conda_build_configs", "./tests/conda_build_config.yaml", env_file, "--python_versions", constants.DEFAULT_PYTHON_VERS, "--build_types", "cuda"])
 
 def test_validate_negative(mocker):
     '''
@@ -191,7 +191,7 @@ def test_validate_negative(mocker):
 
     env_file = os.path.join(test_dir, 'test-env2.yaml')
     with pytest.raises(OpenCEError) as err:
-        opence._main(["validate", validate_config.COMMAND, "--conda_build_configs", "./tests/conda_build_config.yaml", env_file, "--python_versions", utils.DEFAULT_PYTHON_VERS, "--build_types", "cuda"])
+        opence._main(["validate", validate_config.COMMAND, "--conda_build_configs", "./tests/conda_build_config.yaml", env_file, "--python_versions", constants.DEFAULT_PYTHON_VERS, "--build_types", "cuda"])
     assert "Error validating \"" in str(err.value)
     assert "conda_build_config.yaml\']\" for " in str(err.value)
     assert "Dependencies are not compatible.\nCommand:\nconda create" in str(err.value)
@@ -231,7 +231,7 @@ def test_validate_bad_env(mocker):
     )
     env_file = os.path.join(test_dir, 'test-env-invalid1.yaml')
     with pytest.raises(OpenCEError) as err:
-        opence._main(["validate", validate_config.COMMAND, "--conda_build_configs", "./tests/conda_build_config.yaml", env_file, "--python_versions", utils.DEFAULT_PYTHON_VERS, "--build_types", "cuda"])
+        opence._main(["validate", validate_config.COMMAND, "--conda_build_configs", "./tests/conda_build_config.yaml", env_file, "--python_versions", constants.DEFAULT_PYTHON_VERS, "--build_types", "cuda"])
     assert "Error validating \"" in str(err.value)
     assert "conda_build_config.yaml\']\" for " in str(err.value)
     assert "Unexpected key chnnels was found in " in str(err.value)


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
This PR does following -
1. Fixes the issue below: 
**Issue**: Package name generated in conda env files has different hash than what the actual package is built with. For e.g.
opence-conda-env-py3.10-cpu-openmpi.yaml has libevent package name as `- libevent 2.1.11.* h9983d05_4` whereas the package is built with name `libevent-2.1.11-hbb84724_4.conda`. 
**Cause**: This difference is due to the addition of `ppc_arch_variant` in the conda config for libevent package during conda env file generation. But it was not being added when the package was built in `build_feedstock.py`
**Fix**: `ppc_arch_variant` is added in both the flows so that the package hash is same while writing conda env file as well as during the build. Also, the global variable named `PPC_ARCH_VARIANT` was not being set rightly. So, it is also corrected by adding opence_globals.py and defining that global variable there. 

2. Refactoring of the code - 
Created constants.py to have all the constant variables defined in it and utils.py to hold all the utility functions. Updated all the files to work with this separation of the code of utils.py. 

## Review process to land 

1. All tests and other checks must succeed.
4. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
5. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
