### PR TITLE
Better handling of bazel shutdown process and modified logic

### DIFF
--- a/build_utils/open-ce-common-utils.sh
+++ b/build_utils/open-ce-common-utils.sh
@@ -21,7 +21,7 @@ function cleanup_bazel {
     if [[ $? -eq 0 ]]; then
         echo "bazel shutdown completed successfully"
     else
-        echo "bazel shutdown failed, now trying to kill bazel process ID"
+        echo "bazel shutdown failed, now trying to kill bazel process ID: $1"
         kill -9 $1 && wait $!
     fi
 }

--- a/build_utils/open-ce-common-utils.sh
+++ b/build_utils/open-ce-common-utils.sh
@@ -17,12 +17,5 @@
 # This script can contain common functions needed by feedstocks during the builds.
 
 function cleanup_bazel {
-    ARCH=`uname -m`
-    if [[ $ARCH == "x86_64" ]]; then
-        kill -9 $1
-    else
-        bazel clean --expunge
-        bazel shutdown
-    fi
-  
+    (echo "Trying bazel shutdown" && bazel clean --expunge && bazel shutdown) || (echo "Trying to kill bazel process ID" && kill -9 $1 && wait $!)
 }

--- a/build_utils/open-ce-common-utils.sh
+++ b/build_utils/open-ce-common-utils.sh
@@ -17,5 +17,11 @@
 # This script can contain common functions needed by feedstocks during the builds.
 
 function cleanup_bazel {
-    (echo "Trying bazel shutdown" && bazel clean --expunge && bazel shutdown) || (echo "Trying to kill bazel process ID" && kill -9 $1 && wait $!)
+    bazel clean --expunge && bazel shutdown
+    if [[ $? -eq 0 ]]; then
+        echo "bazel shutdown completed successfully"
+    else
+        echo "bazel shutdown failed, now trying to kill bazel process ID"
+        kill -9 $1 && wait $!
+    fi
 }


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

I've made the following changes in the bazel cleanup function -

1. Added wait for kill to finish. If kill is not finished and bash completes without waiting for it, subsequent `bazel build` tries to call `bazel shutdown`  on the previous unkilled (zombie) process and then the same error occurs `FATAL: Attempted to kill stale server process (pid=3292) using SIGKILL, but it did not die in a timely fashion.`
2. Changed the logic in a way so that `kill -9 ` won't be called blindly on x86 always. The cleanup function would attempt to call `bazel shutdown` first and if it fails then it will forcefully kill the PID. So, for the folks who use our recipes and open-ce-builder locally, they will still get the default behavior of `bazel shutdown`.
 

## Review process to land 

1. All tests and other checks must succeed.
4. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
5. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
