### PR TITLE
Make cyclic dependency error as warning

### DIFF
--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -29,7 +29,7 @@ from open_ce import graph
 from open_ce import env_config
 from open_ce import validate_config     #pylint: disable=cyclic-import
 from open_ce import build_feedstock
-from open_ce.errors import OpenCEError, Error, log
+from open_ce.errors import OpenCEError, Error, log, show_warning
 from open_ce.conda_env_file_generator import CondaEnvFileGenerator
 from open_ce.build_command import BuildCommand
 # pylint: enable=wrong-import-position,wrong-import-order
@@ -490,7 +490,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                 cycle_print += " -> ".join(node.build_command.recipe if node.build_command else str(node.packages)
                                                         for node in cycle + [cycle[0]]) + "\n"
         if cycle_print:
-            raise OpenCEError(Error.BUILD_TREE_CYCLE, cycle_print)
+            show_warning(Error.BUILD_TREE_CYCLE, cycle_print)
 
     def build_command_dependencies(self, node):
         '''

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -532,7 +532,7 @@ def test_build_tree_len():
 
     assert len(mock_build_tree) == 3
 
-def test_build_tree_cycle_fail(mocker, caplog):
+def test_build_tree_cycle_fail(_mocker, caplog):
     '''
     Tests that a cycle is detected in a build_tree.
     '''

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -532,7 +532,7 @@ def test_build_tree_len():
 
     assert len(mock_build_tree) == 3
 
-def test_build_tree_cycle_fail(_mocker, caplog):
+def test_build_tree_cycle_fail(mocker, caplog): #pylint: disable=unused-argument
     '''
     Tests that a cycle is detected in a build_tree.
     '''

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -532,7 +532,7 @@ def test_build_tree_len():
 
     assert len(mock_build_tree) == 3
 
-def test_build_tree_cycle_fail():
+def test_build_tree_cycle_fail(mocker, caplog):
     '''
     Tests that a cycle is detected in a build_tree.
     '''
@@ -573,15 +573,14 @@ def test_build_tree_cycle_fail():
 
     mock_build_tree._tree = cycle_build_commands
 
-    with pytest.raises(OpenCEError) as exc:
-        mock_build_tree._detect_cycle()
+    mock_build_tree._detect_cycle()
 
-    assert "Build dependencies should form a Directed Acyclic Graph." in str(exc.value)
-    assert any(["recipe1 -> recipe2 -> recipe1" in str(exc.value),
-                "recipe2 -> recipe1 -> recipe2" in str(exc.value),
-                "recipe1 -> recipe3 -> recipe2 -> recipe1" in str(exc.value),
-                "recipe2 -> recipe1 -> recipe3 -> recipe2" in str(exc.value),
-                "recipe3 -> recipe2 -> recipe1 -> recipe2" in str(exc.value)])
+    assert "Build dependencies should form a Directed Acyclic Graph." in caplog.text
+    assert any(["recipe1 -> recipe2 -> recipe1" in caplog.text,
+                "recipe2 -> recipe1 -> recipe2" in caplog.text,
+                "recipe1 -> recipe3 -> recipe2 -> recipe1" in caplog.text,
+                "recipe2 -> recipe1 -> recipe3 -> recipe2" in caplog.text,
+                "recipe3 -> recipe2 -> recipe1 -> recipe2" in caplog.text])
 
 def test_get_installable_package_for_non_runtime_package():
     '''


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Whenever build tree is created it checks if there are any cyclic dependencies for envs/feedstocks being built. We used to throw an error if there is one. Ideally conda-build allows the build even if there is cyclic dependency found. So, we should also throw a warning instead of error. 


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
