### PR TITLE
pin matplotlib to fix test failure

### DIFF
--- a/.github/workflows/builder-unit-test.yml
+++ b/.github/workflows/builder-unit-test.yml
@@ -35,7 +35,7 @@ jobs:
           conda install -y pylint=2.12.2 \
                            conda-build \
                            networkx \
-                           matplotlib \
+                           matplotlib=3.5.* \
                            junit-xml \
                            pytest=6.2.4 \
                            pytest-cov=2.12.1 \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The `open-ce` tool allows a user to build collections of conda recipes described
 
 ## GETTING STARTED
 
+
 ### Requirements
 
 * `conda` 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The `open-ce` tool allows a user to build collections of conda recipes described
 
 ## GETTING STARTED
 
-
 ### Requirements
 
 * `conda` 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

pin matplotlib to resolve the following error:
```
        if ax is None:
>           if cf._axstack() is None:
E           TypeError: '_AxesStack' object is not callable
```
Ref - https://github.com/Qiskit/rustworkx/issues/680

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
