### PR TITLE
add dockerfile for s390x as it needs openssl3

### DIFF
--- a/open_ce/images/builder/Dockerfile-s390x
+++ b/open_ce/images/builder/Dockerfile-s390x
@@ -1,0 +1,50 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
+ENV PATH=$CONDA_HOME/bin:$PATH
+
+ENV OPEN_CE_CONDA_BUILD=3.22.0
+ENV OPEN_CE_CONDA=4.14
+ENV OPENSSL_VER=3.*
+
+ENV CICD_GROUP=cicd
+ARG GROUP_ID=1500
+ENV BUILD_USER=builder
+ARG BUILD_ID=1084
+
+RUN export ARCH="$(uname -m)" && \
+    yum repolist && yum install -y rsync openssh-clients diffutils procps binutils git-lfs glibc-devel file psmisc openssl openssl-libs openssl-devel && \
+    # Create CICD Group
+    groupadd --non-unique --gid ${GROUP_ID} ${CICD_GROUP} && \
+    # Adduser Builder
+    useradd -b /home --non-unique --create-home --gid ${GROUP_ID} --groups wheel \
+    --uid ${BUILD_ID} --comment "User for Building" ${BUILD_USER} && \
+    curl -o /tmp/anaconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-${ARCH}.sh && \
+    chmod +x /tmp/anaconda.sh && \
+    /bin/bash /tmp/anaconda.sh -f -b -p /opt/conda && \
+    rm -f /tmp/anaconda.sh && \
+    $CONDA_HOME/bin/conda install -y conda-build=${OPEN_CE_CONDA_BUILD} conda=${OPEN_CE_CONDA} networkx git junit-xml patch && \
+    $CONDA_HOME/bin/conda config --system --add envs_dirs $CONDA_HOME/envs && \
+    $CONDA_HOME/bin/conda config --system --add pkgs_dirs $CONDA_HOME/pkgs && \
+    $CONDA_HOME/bin/conda config --system --set always_yes true && \
+    $CONDA_HOME/bin/conda config --system --set auto_update_conda false && \
+    $CONDA_HOME/bin/conda config --system --set notify_outdated_conda false && \
+    $CONDA_HOME/bin/conda config --system --add create_default_packages openssl=${OPENSSL_VER} && \
+    $CONDA_HOME/bin/conda --version && \
+    mkdir -p $CONDA_HOME/conda-bld && \
+    mkdir -p $HOME/.cache && \
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
+    chown -R ${BUILD_USER}:${CICD_GROUP} ${CONDA_HOME} && \
+    git config --global http.version HTTP/1.1 && \
+    git config --global http.postBuffer 157286400
+
+USER ${BUILD_USER}
+RUN export PATH="${PATH}" && \
+    echo "PATH="${PATH}"" >> ${HOME}/.profile && \
+    mkdir -p $HOME/.cache && \
+    echo ". $CONDA_HOME/etc/profile.d/conda.sh" >> ${HOME}/.bashrc && \
+    echo "export PYTHONPATH=${PYTHONPATH}:$HOME/open_ce" >> ${HOME}/.bashrc && \
+    echo "conda activate base" >> ${HOME}/.bashrc && \
+    git config --global http.version HTTP/1.1 && \
+    git config --global http.postBuffer 157286400
+


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

To enable builds on s390x with openssl 3.* use a separate Dockefile for s390x. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
