### PR TITLE
remove tagging for openssl-env

### DIFF
--- a/git_tools/create_opence_release.py
+++ b/git_tools/create_opence_release.py
@@ -87,11 +87,10 @@ def _main(arg_strings=None): # pylint: disable=too-many-locals, too-many-stateme
     version_msg = f"Open-CE Version {version}"
     release_name = f"v{version}"
 
-    openssl_env = os.path.abspath(os.path.join(primary_repo_path, "envs", "openssl-env.yaml"))
     variants = utils.ALL_VARIANTS()
     env_file_contents = []
     for variant in variants:
-        env_file_contents += env_config.load_env_config_files([open_ce_env_file, openssl_env],
+        env_file_contents += env_config.load_env_config_files([open_ce_env_file],
                                                           [variant], ignore_urls=True)
     for env_file_content in env_file_contents:
         env_file_tag = env_file_content.get(env_config.Key.git_tag_for_env.name, None)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

openssl-env is removed from opence. So removing its tagging. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
